### PR TITLE
Registry build commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Pre-commit hook to ensure registry is up to date
+# This prevents pushing component updates with an outdated registry
+
+# Get list of staged files
+STAGED_FILES=$(git diff --cached --name-only)
+
+# Check if any registry source files are being committed
+# This includes: registry/, hooks/, lib/, registry.json, components.json
+REGISTRY_CHANGED=$(echo "$STAGED_FILES" | grep -E '^(registry/|hooks/|lib/|registry\.json|components\.json)' || true)
+
+if [ -z "$REGISTRY_CHANGED" ]; then
+  # No registry-related files are being committed, skip the check
+  exit 0
+fi
+
+echo "🔨 Registry source files detected in commit, building registry..."
+
+# Build the registry
+pnpm build:registry
+
+# Check if any files in public/r/ were modified after the build
+REGISTRY_DIFF=$(git diff --name-only public/r/)
+
+if [ -n "$REGISTRY_DIFF" ]; then
+  echo ""
+  echo "📦 Registry files were updated by the build:"
+  echo "$REGISTRY_DIFF" | sed 's/^/   /'
+  echo ""
+  echo "✅ Automatically staging updated registry files..."
+  
+  # Stage the updated registry files
+  git add public/r/
+  
+  echo "   Done! Registry files have been added to your commit."
+fi
+
+echo ""

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:registry": "shadcn build",
     "lint": "eslint",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare": "husky"
   },
   "dependencies": {
     "@joycostudio/marquee": "^0.0.12",
@@ -31,8 +32,8 @@
     "fumadocs-core": "16.2.3",
     "fumadocs-mdx": "14.0.4",
     "fumadocs-ui": "16.2.3",
-    "hls.js": "^1.6.15",
     "gray-matter": "^4.0.3",
+    "hls.js": "^1.6.15",
     "jotai": "^2.15.1",
     "lucide-react": "^0.552.0",
     "media-chrome": "^4.17.2",
@@ -58,6 +59,7 @@
     "eslint": "^9.39.1",
     "eslint-config-next": "16.0.1",
     "eslint-config-prettier": "^10.1.8",
+    "husky": "^9.1.7",
     "postcss": "^8.5.6",
     "prettier": "^3.7.3",
     "prettier-plugin-tailwindcss": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2832,6 +2835,11 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -7516,6 +7524,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.6.3:
     dependencies:


### PR DESCRIPTION
Adds a pre-commit hook to automatically build the registry and stage updated files when registry source files are changed.

---
<a href="https://cursor.com/background-agent?bcId=bc-978deeae-4bbf-48ae-bc30-e48d94fc5389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-978deeae-4bbf-48ae-bc30-e48d94fc5389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

