### PR TITLE
Documentation url standard

### DIFF
--- a/content/logs/02-ai-driven-development.mdx
+++ b/content/logs/02-ai-driven-development.mdx
@@ -65,9 +65,7 @@ It works better for agent conversations because:
 - **It’s consistent**: every docs link follows the same shape, so it’s easy to produce and scan.
 - **It’s unambiguous context**: dropping a `.md` link in a prompt clearly signals “use this as documentation source”.
 
-Example (this page):
-
-- [`https://registry.joyco.studio/logs/02-ai-driven-development.md`](https://registry.joyco.studio/logs/02-ai-driven-development.md)
+This page, for example, [supports this pattern](https://registry.joyco.studio/logs/02-ai-driven-development.md).
 
 ## About reviews
 


### PR DESCRIPTION
Add a section to `02-ai-driven-development.mdx` recommending the use of `.md` suffixes for documentation URLs to improve predictability, tool-friendliness, and stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-29c71c87-66f5-47f6-9418-98cb70c328ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29c71c87-66f5-47f6-9418-98cb70c328ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR adds a new section "Referencing documentation" to the AI-driven development log that documents the practice of using `.md` URL suffixes when sharing documentation links with AI agents. The addition provides clear rationale (cleaner content, consistency, unambiguous context) and includes a practical example using the current page's URL.


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are purely documentation additions that explain a URL standard for agent conversations. No code logic, dependencies, or runtime behavior is affected. The content is clear, well-structured, and provides practical guidance with concrete examples.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| content/logs/02-ai-driven-development.mdx | Added documentation referencing guidelines section recommending `.md` URLs for agent conversations |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->