### PR TITLE
[PROPOSAL]: Add `ARCHITECTURE.md` to `AGENTS.md`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,41 @@
+# JOYCO Registry Architecture
+
+## Overview
+
+The project is a Next.js App Router site that serves Fumadocs-based documentation, a shadcn-compatible component registry, and demo views for registry blocks. Content is MDX-first and rendered through Fumadocs layouts and page components.
+
+## Data Management
+
+- **MDX content** lives in `content/` and is typed/validated by `source.config.ts` using Fumadocs schemas.
+- **Fumadocs source** is built in `lib/source.ts` and provides a shared page tree and metadata for docs, search, OG images, and LLM exports.
+- **Registry definitions** live in `registry.json` and component source files under `registry/joyco/blocks/`.
+- **Registry artifacts** are served from `public/r/` (JSON registry output consumed by shadcn tooling).
+- **External registry mapping** is read from MDX frontmatter via `lib/external-registries.ts` and used to generate Next.js redirects.
+- **Client-side config state** uses Jotai with `atomWithStorage` in `hooks/use-config.ts` to persist UI preferences in localStorage.
+- **Demo inventory** is discovered from `demos/` by `lib/registry-examples.ts` and exposed to demo routes.
+
+## Data Fetching Patterns
+
+- **Static generation** is the default: docs pages, LLM markdown routes, OG images, and demo pages all use `generateStaticParams` and set `revalidate = false` where applicable.
+- **Server-side fetches** call external services:
+  - `lib/stats.ts` fetches weekly download stats from `https://workers.joyco.studio`.
+  - `lib/track.ts` posts download events (requires `JOYCO_WORKER_SECRET`).
+- **Search** is served via `app/api/search/route.ts` using `fumadocs-core` server search helpers.
+- **LLM exports** are served from `app/llm/[[...slug]]/route.ts` and mapped from `.md` URLs via Next.js rewrites in `next.config.ts`.
+
+## Layout and Rendering Patterns
+
+- **Root layout** (`app/layout.tsx`) applies global CSS, fonts, and wraps pages in `RootProvider`.
+- **Docs layout** (`app/(registry)/layout.tsx`) uses `DocsLayout` with `source.pageTree` and shared nav options from `lib/layout.shared.tsx`.
+- **Docs rendering** (`app/(registry)/[[...slug]]/page.tsx`) composes `DocsPage`, TOC, and MDX rendering via `mdx-components.tsx`.
+- **Demo rendering** (`app/(view)/view/[name]/page.tsx`) resolves demo components from `demos/` and renders them with `Suspense`.
+- **OG images** are generated in `app/og/docs/[...slug]/route.tsx` using `next/og` and Fumadocs’ default image generator.
+
+## Key Paths
+
+- `app/` — App Router routes, layouts, API endpoints, LLM and OG image routes.
+- `content/` — MDX documentation source.
+- `registry/` — Registry component source files.
+- `public/r/` — Published registry JSON assets.
+- `lib/` — Fumadocs source loader, registry helpers, and fetch utilities.
+- `hooks/` — Client-side state hooks (Jotai-based config).

--- a/public/AGENTS.md
+++ b/public/AGENTS.md
@@ -9,3 +9,11 @@ Use `data-slot` attributes for inner elements and keep a single `className` on t
 ## Use max-{breakpoint} variants for responsive hiding
 
 When hiding elements below specific breakpoints, use Tailwind's max-{breakpoint} variants with the `hidden` class while keeping the default display value intact (e.g., `flex max-sm:hidden`). This approach prevents consumers from accidentally overriding the component's display behavior, as they might incorrectly assume the base state and apply conflicting classes like `hidden sm:block`.
+
+## Maintain ARCHITECTURE.md at the project root
+
+Keep an `ARCHITECTURE.md` file at the repository root and update it after significant architectural updates. It should capture the current data management approach, data fetching patterns, and layout/rendering patterns so contributors and agents have a single, up-to-date reference.
+
+## Read ARCHITECTURE.md for architecture context
+
+Review `ARCHITECTURE.md` at the repository root before making or reviewing architectural changes to ensure decisions align with the current system.

--- a/public/guidelines/architecture-doc-updates.md
+++ b/public/guidelines/architecture-doc-updates.md
@@ -1,0 +1,33 @@
+---
+reference: https://registry.joyco.studio/toolbox/pr-guidelines#architecture-doc-updates
+---
+
+# Keep ARCHITECTURE.md Updated
+
+### What
+
+Maintain an `ARCHITECTURE.md` file at the repository root. When a change constitutes a significant architectural update, update `ARCHITECTURE.md` in the same PR to reflect the new state of the system.
+
+### Why
+
+Architecture decisions quickly become tribal knowledge. A single, up-to-date document helps agents and future contributors understand the current data management approach, data fetching patterns, and layout/rendering patterns without reverse-engineering the codebase.
+
+### Review Requirement
+
+Code diff review agents should require an `ARCHITECTURE.md` update when a change materially affects:
+
+- Data management (e.g., new state containers, caching layers, stores, or shared context boundaries).
+- Data fetching patterns (e.g., new fetch client, batching/streaming changes, SSR/CSR shifts, or query ownership changes).
+- Layout and rendering patterns (e.g., route hierarchy, streaming/partial rendering, suspense boundaries, or layout composition strategy).
+
+### Examples
+
+**Needs ARCHITECTURE.md update**
+- Migrating from local state to a global store or new context hierarchy.
+- Moving data fetching from client components to server components (or vice-versa).
+- Updating the data-fetching mechanism (migrating from react-query to swr).
+- Introducing a new layout shell, route grouping strategy, or streaming rendering model.
+
+**Does not require update**
+- Localized refactors that keep the existing architecture intact.
+- Minor component moves that do not change data flow or rendering strategy.


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR establishes a new documentation practice by creating `ARCHITECTURE.md` at the repository root and adding corresponding guidelines to maintain it. The changes introduce:

- A comprehensive architecture document capturing the current state of data management (MDX content, Fumadocs source, registry definitions, Jotai-based config), data fetching patterns (static generation, server-side fetches, search API), and layout/rendering patterns (Next.js App Router structure)
- Two new sections in `public/AGENTS.md` instructing contributors and agents to maintain and reference the architecture document
- A detailed guideline at `public/guidelines/architecture-doc-updates.md` explaining when architecture updates are required and providing concrete examples

The implementation follows existing guideline patterns with proper frontmatter references and clear What/Why/How structure. All content is well-organized, technically accurate, and aligns with the project's documentation standards.


</details>
<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it only adds documentation and guidelines without modifying any application code
- The PR introduces helpful documentation that improves maintainability. All files follow existing patterns, contain accurate technical information, and align with the repository's documentation standards. No code logic is changed.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ARCHITECTURE.md | New architecture documentation file added at repository root describing data management, fetching patterns, and rendering structure |
| public/AGENTS.md | Added two guidelines about maintaining and reading `ARCHITECTURE.md` for architectural context |
| public/guidelines/architecture-doc-updates.md | New guideline document explaining when and how to update `ARCHITECTURE.md`, with clear examples and review requirements |

</details>


</details>


<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - Registry Guidelines ([source](https://app.greptile.com/review/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))

<!-- /greptile_comment -->