### PR TITLE
Doc link styling variant

### DIFF
--- a/components/layout/doc-links.tsx
+++ b/components/layout/doc-links.tsx
@@ -35,7 +35,7 @@ export function DocLinks({
         <Button
           key={link.href}
           asChild
-          variant="accent"
+          variant="secondary"
           size="sm"
           className="font-mono tracking-wide uppercase"
         >


### PR DESCRIPTION
Update doc links to use `secondary` variant styling instead of `accent`.

---
<a href="https://cursor.com/background-agent?bcId=bc-224195e7-39f0-44d8-8985-4c1a363df6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-224195e7-39f0-44d8-8985-4c1a363df6c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

