### PR TITLE
Add ancestor state styling section to Tailwind docs

### DIFF
--- a/content/toolbox/tailwind.mdx
+++ b/content/toolbox/tailwind.mdx
@@ -37,4 +37,4 @@ Use the `in-*` variant to style an element based on an ancestor's state or class
 
 This targets the element when it's inside an ancestor with the `.notifs-drawer-open` class.
 
-Reference -> [in-* variant docs](https://tailwindcss.com/docs/hover-focus-and-other-states#styling-based-on-an-ancestor-with-a-specific-class)
+Reference -> [in-* variant docs](https://tailwindcss.com/docs/hover-focus-and-other-states#implicit-groups)


### PR DESCRIPTION
Document the in-* variant for styling elements based on ancestor state or class, useful for drawer overlays and conditional layouts.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Added documentation for Tailwind's `in-*` variant, which allows styling elements based on ancestor state or class. The new section follows the existing documentation structure and includes a practical example for drawer overlays.

- Clear explanation of the `in-*` variant functionality
- Practical code example showing usage with a drawer overlay scenario
- Proper reference link to official Tailwind CSS documentation
- Consistent formatting with other sections in the file
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes add straightforward documentation without modifying any code or functionality. The content is accurate, follows existing patterns, and includes a proper reference to official Tailwind documentation.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->