### PR TITLE
Reduce striped pattern line thickness in dark mode

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -229,11 +229,11 @@ code::-webkit-scrollbar-thumb:hover {
     background-image: repeating-linear-gradient(
       0deg,
       rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.5) 3px,
-      rgba(0, 0, 0, 0.9) 3px,
-      rgba(0, 0, 0, 0.9) 6px
+      rgba(0, 0, 0, 0.5) 1px,
+      rgba(0, 0, 0, 0.9) 1px,
+      rgba(0, 0, 0, 0.9) 2px
     );
-    background-size: 100% 6px;
+    background-size: 100% 2px;
   }
 }
 


### PR DESCRIPTION
## Summary
Adjusted the striped background pattern used in dark mode to use thinner lines, creating a more subtle visual effect.

## Changes
- Reduced repeating linear gradient stripe width from 3px to 1px for the darker stripe
- Reduced the lighter stripe width from 3px to 1px
- Reduced the overall pattern repeat size from 6px to 2px
- This creates a finer, more refined striped pattern while maintaining the same visual contrast

## Details
The striped pattern is used as a background effect in dark mode. By reducing the stripe thickness from 3px to 1px and the overall pattern cycle from 6px to 2px, the pattern becomes less visually prominent and more aesthetically refined, while still providing the same visual distinction.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Reduced the `.cctv-backdrop` striped pattern line thickness from 3px to 1px and the repeat cycle from 6px to 2px, creating a finer and more subtle visual effect while maintaining the same contrast ratio.

- The change is purely cosmetic and improves visual aesthetics
- Used in backdrop overlays across command palette, mobile nav, and typewriter demo
- CSS syntax is correct and semantically sound
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple CSS visual refinement that adjusts stripe thickness in a background pattern. The syntax is correct, maintains the same contrast ratio, and is purely cosmetic with no functional impact or risk.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/styles/globals.css | Reduced CCTV backdrop stripe pattern from 3px to 1px for a more refined visual effect |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->