### PR TITLE
Fix dark theme background to bluish black

### DIFF
--- a/app/styles/theming.css
+++ b/app/styles/theming.css
@@ -41,7 +41,7 @@
 }
 
 .dark {
-  --background: oklch(0.1684 0 0);
+  --background: oklch(0.1684 0.02 260);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.2046 0 0);
   --card-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
Change --background in .dark from pure neutral oklch(0.1684 0 0)
to a subtle blue-tinted oklch(0.1684 0.02 260), adding warmth and
depth to the dark theme.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the dark theme background token in `app/styles/theming.css` by changing `--background` from a neutral `oklch(0.1684 0 0)` to a subtle blue-tinted `oklch(0.1684 0.02 260)`, affecting any components that reference the `--background` CSS variable under the `.dark` class.
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a single CSS variable value update confined to the `.dark` theme; it is syntactically valid OKLCH and does not alter selectors or introduce new dependencies.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/styles/theming.css | Updates the `.dark` theme `--background` OKLCH value to add a subtle blue tint; no functional issues found. |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->