### PR TITLE
Add GitHub to quicklinks

### DIFF
--- a/public/quicklinks.json
+++ b/public/quicklinks.json
@@ -7,6 +7,7 @@
   { "name": "Claude Cloud Agent", "link": "https://claude.ai/code" },
   { "name": "ChatGPT", "link": "https://chatgpt.com/" },
   { "name": "Cursor Cloud Agents", "link": "https://cursor.com/agents" },
+  { "name": "GitHub", "link": "https://github.com" },
   { "name": "Linear", "link": "linear.app" },
   { "name": "Shadcn", "link": "https://ui.shadcn.com/docs/components" },
   { "name": "Dice UI", "link": "https://www.diceui.com/docs/introduction" },


### PR DESCRIPTION
## Summary
Added GitHub to the quicklinks list for easier access to the GitHub platform.

## Changes
- Added GitHub quicklink entry (`https://github.com`) to `public/quicklinks.json`

## Details
The GitHub link has been inserted in alphabetical order within the quicklinks configuration, positioned between "Cursor Cloud Agents" and "Linear" entries.

https://claude.ai/code/session_011oRkHerRreSF32jpKTnMWT

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

Added GitHub (`https://github.com`) to the quicklinks configuration in alphabetical order between Cursor Cloud Agents and Linear.

- The new entry follows the correct JSON structure and formatting
- Positioned correctly in alphabetical order
- Uses proper `https://` protocol prefix
- While reviewing, noticed the Linear entry on line 11 is missing the `https://` protocol prefix (pre-existing issue)
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor protocol consistency fix recommended
- The PR correctly adds GitHub to quicklinks in alphabetical order with proper formatting. Score is 4/5 because there's a pre-existing inconsistency in the Linear entry that should be addressed for consistency
- Check `public/quicklinks.json` line 11 for protocol prefix consistency

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| public/quicklinks.json | Added GitHub quicklink in alphabetical order; found existing protocol inconsistency in Linear entry |

</details>


</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->