### PR TITLE
Remove horizontal dividers from skills documentation

### DIFF
--- a/content/toolbox/skills.mdx
+++ b/content/toolbox/skills.mdx
@@ -63,4 +63,4 @@ Analyze a Chrome DevTools Performance trace JSON file for performance anomalies.
 /trace-audit <path-to-trace.json>
 ```
 
-Runs 13 detection categories in parallel, Long Tasks, Layout Thrashing, Forced Reflows, rAF Ticker Loops, Style Recalc Storms, Paint Storms, GC Pressure, CLS, INP, Network Errors, Redundant Fetches, Script Eval, and Long Animation Frames, then produces a structured audit report with severity classifications and timeline hotspots.
+Runs 13 detection categories in parallel: Long Tasks, Layout Thrashing, Forced Reflows, rAF Ticker Loops, Style Recalc Storms, Paint Storms, GC Pressure, CLS, INP, Network Errors, Redundant Fetches, Script Eval, and Long Animation Frames, then produces a structured audit report with severity classifications and timeline hotspots.


### PR DESCRIPTION
## Summary
Removed horizontal divider lines (`----`) that were separating skill sections in the toolbox documentation.

## Changes
- Removed three `----` dividers that appeared between skill sections:
  - Between `parallel-claude` and `pr-description-writer`
  - Between `pr-description-writer` and `markdown-content`
  - Between `markdown-content` and `trace-audit`

## Details
This cleanup improves the visual flow of the skills documentation by relying on section headers and whitespace for separation rather than explicit horizontal dividers. The content and structure of each skill section remains unchanged.

https://claude.ai/code/session_01WxLCtPztWu7YyajJJUzFRq

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes horizontal dividers from the skills documentation page and replaces em dashes with standard punctuation (commas, periods, colons) for improved readability.

- Removed three `---` horizontal dividers between skill sections
- Replaced em dashes with commas/periods/colons in multiple sentences
- One grammatical issue identified: run-on sentence in the `trace-audit` description needs conjunction before final list item
</details>


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the minor grammar issue
- The changes are purely cosmetic documentation improvements with one minor grammatical error that should be corrected
- No files require special attention beyond the grammar fix in `content/toolbox/skills.mdx`

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| content/toolbox/skills.mdx | Removed horizontal dividers and changed em dashes to standard punctuation; minor grammar issue in last sentence |

</details>


</details>


<sub>Last reviewed commit: fa8f63d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->