### PR TITLE
FIX: wrong dynamic rending

### DIFF
--- a/app/(registry)/layout.tsx
+++ b/app/(registry)/layout.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from 'react'
-import { cookies } from 'next/headers'
 import {
   source,
   getGameSlugs,
@@ -16,21 +15,19 @@ import { MobileNav } from '@/components/layout/mobile-nav'
 import { getExperiments } from '@/lib/lab'
 import { CommandPalette } from '@/components/layout/command-palette'
 
-export default async function Layout({ children }: LayoutProps<'/'>) {
-  const cookieStore = await cookies()
-  const isTeam = cookieStore.has('joyco-team')
-
-  const itemMeta: Record<
-    string,
-    {
-      badge?: 'new' | 'updated' | 'internal'
-      dot?: 'red' | 'blue' | 'green' | 'yellow'
-      hidden?: boolean
-    }
-  > = {
-    '/toolbox/skills': { badge: 'new' },
-    '/toolbox/ui': isTeam ? { badge: 'internal' } : { hidden: true },
+const itemMeta: Record<
+  string,
+  {
+    badge?: 'new' | 'updated' | 'internal'
+    dot?: 'red' | 'blue' | 'green' | 'yellow'
+    hidden?: boolean
   }
+> = {
+  '/toolbox/skills': { badge: 'new' },
+  '/toolbox/ui': { hidden: true },
+}
+
+export default async function Layout({ children }: LayoutProps<'/'>) {
   const gameSlugs = getGameSlugs()
   const effectSlugs = getEffectSlugs()
   const canvasSlugs = getCanvasSlugs()

--- a/app/api/screenshot/route.ts
+++ b/app/api/screenshot/route.ts
@@ -108,7 +108,7 @@ const getCachedExperimentScreenshot = unstable_cache(
     )
   },
   ['experiment-screenshot'],
-  { revalidate: 86400 }
+  { revalidate: 604800 }
 )
 
 export async function GET(request: NextRequest) {
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest) {
     return new NextResponse(imageBuffer, {
       headers: {
         'Content-Type': 'image/png',
-        'Cache-Control': 'public, s-maxage=31536000',
+        'Cache-Control': 'public, max-age=604800, s-maxage=604800, stale-while-revalidate=86400',
       },
     })
   } catch (error) {

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -16,6 +16,7 @@ import FileIcon from '@/components/icons/file'
 import FlaskIcon from '@/components/icons/flask'
 import type { SidebarItemMeta } from './sidebar/section'
 import type { Experiment } from '@/lib/lab'
+import { useIsTeam } from '@/hooks/use-team-cookie'
 import { MetaBadge } from '@/components/layout/meta-badge'
 import { SearchResults } from './sidebar/search-results'
 import { NoResults } from './sidebar/no-results'
@@ -52,9 +53,17 @@ const sectionIcons: Record<
 
 export function MobileNav({
   tree,
-  itemMeta = {},
+  itemMeta: itemMetaProp = {},
   experiments = [],
 }: MobileNavProps) {
+  const isTeam = useIsTeam()
+  const itemMeta = React.useMemo(
+    () =>
+      isTeam
+        ? { ...itemMetaProp, '/toolbox/ui': { badge: 'internal' as const } }
+        : itemMetaProp,
+    [isTeam, itemMetaProp]
+  )
   const pathname = usePathname()
   const router = useRouter()
   const inputRef = React.useRef<HTMLInputElement>(null)

--- a/components/layout/sidebar/index.tsx
+++ b/components/layout/sidebar/index.tsx
@@ -13,6 +13,7 @@ import { LabSidebarSection } from './lab-section'
 import { SocialLinks } from './social-links'
 import { NavAside } from '../nav-aside'
 import { useSearch } from '@/hooks/use-search'
+import { useIsTeam } from '@/hooks/use-team-cookie'
 import type { Experiment } from '@/lib/lab'
 
 export type { SidebarItemMeta }
@@ -34,6 +35,14 @@ export function RegistrySidebar({
   canvasSlugs = [],
   experiments = [],
 }: RegistrySidebarProps) {
+  const isTeam = useIsTeam()
+  const resolvedMeta = React.useMemo(
+    () =>
+      isTeam
+        ? { ...itemMeta, '/toolbox/ui': { badge: 'internal' as const } }
+        : itemMeta,
+    [isTeam, itemMeta]
+  )
   const pathname = usePathname()
   const router = useRouter()
   const {
@@ -106,7 +115,7 @@ export function RegistrySidebar({
         <SidebarSection
           folder={folder}
           defaultOpen
-          meta={itemMeta}
+          meta={resolvedMeta}
           gameSlugs={gameSlugs}
           effectSlugs={effectSlugs}
           canvasSlugs={canvasSlugs}

--- a/hooks/use-team-cookie.ts
+++ b/hooks/use-team-cookie.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from 'react'
+
+function getSnapshot() {
+  return document.cookie.includes('joyco-team')
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+function subscribe(callback: () => void) {
+  const interval = setInterval(callback, 2000)
+  return () => clearInterval(interval)
+}
+
+export function useIsTeam() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a hydration/dynamic-rendering bug by moving the `joyco-team` cookie check from a server component (`layout.tsx`) into a new client-side `useIsTeam` hook backed by `useSyncExternalStore`. Both `RegistrySidebar` and `MobileNav` now resolve the `/toolbox/ui` badge client-side, avoiding the mismatch between server-rendered output and client expectations. The screenshot cache is also tightened to 1-week revalidation with `stale-while-revalidate`.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly addresses the hydration issue; only minor style concerns remain.

The approach (useSyncExternalStore + getServerSnapshot=false) is the idiomatic React pattern for browser-only external stores, and the useMemo dependency arrays are correct. Two P2 findings: missing 'use client' directive and an overly-frequent polling interval, neither of which would cause a production bug today but are worth cleaning up.

hooks/use-team-cookie.ts — should add 'use client' and reconsider the 2-second polling interval.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The `joyco-team` cookie is read client-side only to conditionally show UI; it does not gate access to data or server-side resources.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| hooks/use-team-cookie.ts | New hook using useSyncExternalStore to detect the joyco-team cookie client-side; missing 'use client' directive and polls document.cookie every 2 s unnecessarily. |
| app/(registry)/layout.tsx | Removes server-side cookie read; itemMeta is now a static constant, delegating team detection to client components via useIsTeam. |
| components/layout/sidebar/index.tsx | Adds useIsTeam hook and useMemo to resolve the correct itemMeta client-side, replacing the previous server-driven prop. |
| components/layout/mobile-nav.tsx | Mirrors sidebar change — uses useIsTeam and useMemo to override /toolbox/ui badge for team members on the client. |
| app/api/screenshot/route.ts | Reduces unstable_cache revalidation from 1 day to 1 week and aligns the Cache-Control header to match (7 days + 1-day stale-while-revalidate). |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: hooks/use-team-cookie.ts
Line: 1

Comment:
**Missing `'use client'` directive**

This file uses `useSyncExternalStore` (a React hook) and `document.cookie` in `getSnapshot`. While both consuming components are `'use client'`, the hook file itself should declare `'use client'` to make the browser-only intent explicit and prevent accidental server-component imports from triggering a "hooks cannot be used in Server Components" error at runtime.

```suggestion
'use client'

import { useSyncExternalStore } from 'react'
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: hooks/use-team-cookie.ts
Line: 11-13

Comment:
**Polling every 2 s for a session cookie**

Firing `setInterval` every 2 seconds means `getSnapshot` (and a `document.cookie` parse) runs on every tick for the entire lifetime of the sidebar — even though the `joyco-team` cookie only changes on login/logout. `useSyncExternalStore` is smart enough not to re-render unless the snapshot value changes, but the interval keeps running and accumulates across multiple mounted instances of `RegistrySidebar` and `MobileNav`.

A much longer interval (e.g. 30 s) would achieve the same result with far less overhead.

```suggestion
function subscribe(callback: () => void) {
  const interval = setInterval(callback, 30000)
  return () => clearInterval(interval)
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: wrong dynamic rending"](https://github.com/joyco-studio/hub/commit/f466573c507f72fbd158eb44e3420f4b6d15b5ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27753953)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->