### PR TITLE
fix: team cookie hook review fixes

### DIFF
--- a/hooks/use-team-cookie.ts
+++ b/hooks/use-team-cookie.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useSyncExternalStore } from 'react'
 
 function getSnapshot() {
@@ -8,9 +10,8 @@ function getServerSnapshot() {
   return false
 }
 
-function subscribe(callback: () => void) {
-  const interval = setInterval(callback, 2000)
-  return () => clearInterval(interval)
+function subscribe() {
+  return () => {}
 }
 
 export function useIsTeam() {

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,10 +9,6 @@ export async function proxy(request: NextRequest) {
     await trackRegistryDownload(request)
   }
 
-  if (pathname === '/toolbox/ui' && !request.cookies.has('joyco-team')) {
-    return NextResponse.redirect(new URL('/', request.url))
-  }
-
   if (request.nextUrl.searchParams.get('joyco') === '1') {
     const response = NextResponse.next()
     response.cookies.set('joyco-team', '1', {
@@ -21,6 +17,10 @@ export async function proxy(request: NextRequest) {
       sameSite: 'lax',
     })
     return response
+  }
+
+  if (pathname === '/toolbox/ui' && !request.cookies.has('joyco-team')) {
+    return NextResponse.redirect(new URL('/', request.url))
   }
 
   return NextResponse.next()

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,6 +9,10 @@ export async function proxy(request: NextRequest) {
     await trackRegistryDownload(request)
   }
 
+  if (pathname === '/toolbox/ui' && !request.cookies.has('joyco-team')) {
+    return NextResponse.redirect(new URL('/', request.url))
+  }
+
   if (request.nextUrl.searchParams.get('joyco') === '1') {
     const response = NextResponse.next()
     response.cookies.set('joyco-team', '1', {


### PR DESCRIPTION
## Summary
- Added missing `'use client'` directive to `hooks/use-team-cookie.ts`
- Removed unnecessary 2s polling interval — the cookie is set by middleware before hydration, so `subscribe` can be a no-op

Follow-up to #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the missing `'use client'` directive to `hooks/use-team-cookie.ts` and replaces a 2-second polling interval with a no-op `subscribe` function, asserting that the cookie is always set by middleware before hydration. The `'use client'` fix is correct; the no-op subscribe is a deliberate trade-off that is worth considering against session-lifetime cookie changes.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only concern is that a no-op subscribe will silently skip re-renders if the team cookie changes post-hydration.

Change is small and targeted. The `'use client'` fix is clearly correct. The no-op subscribe is an intentional design decision with a documented rationale, though it carries a stale-state risk for runtime cookie changes.

hooks/use-team-cookie.ts — verify whether team-cookie changes during a session are a realistic scenario that needs reactive updates.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Cookie access is read-only and the `'use client'` directive prevents server-side access to `document.cookie`.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| hooks/use-team-cookie.ts | Adds `'use client'` directive (correct fix) and replaces a 2 s polling interval with a no-op `subscribe`; the no-op means team-status changes after hydration will not trigger re-renders. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: hooks/use-team-cookie.ts
Line: 13-15

Comment:
**No-op `subscribe` silences all runtime cookie changes**

`useSyncExternalStore` with a no-op `subscribe` means React will never re-render consumers of `useIsTeam()` after the initial hydration, even if the `joyco-team` cookie is added, removed, or updated during the session (e.g. sign-out, session expiry, another tab). The justification that "the cookie is set by middleware before hydration" is valid for SSR→hydration consistency, but it doesn't cover post-hydration changes. If team status must stay current, consider subscribing to `document.addEventListener('visibilitychange', ...)` or a storage event as a lightweight way to re-evaluate.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redirect unauthorized access to too..."](https://github.com/joyco-studio/hub/commit/8ad4c68dfc2f99bd43fa3a300ed717cd44fff0fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27754694)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->