### PR TITLE
Mobile nav index links + container-query category grid + TOC truncation

### DIFF
--- a/components/category-quick-links.tsx
+++ b/components/category-quick-links.tsx
@@ -42,111 +42,113 @@ export function CategoryQuickLinks() {
   const isMd = useMediaQuery('(min-width: 768px)')
 
   return (
-    <div className="not-prose grid grid-cols-2 gap-2 sm:grid-cols-2 md:gap-4 lg:grid-cols-3">
-      <CategoryCardLink
-        href="/components"
-        onMouseEnter={() => setActiveIndex(0)}
-        onMouseLeave={() => setActiveIndex(-1)}
-        onFocus={() => setActiveIndex(0)}
-        onBlur={() => setActiveIndex(-1)}
-        className="overflow-visible"
-      >
-        <CategoryCardLinkHeader
-          label="Components"
-          icon={<CubeIcon />}
-          count={counts.components}
-        />
-        <CategoryCardLinkSplash className="relative overflow-visible">
-          <CanvasSequence
-            frameCount={sequences[1].frameCount}
-            frameDuration={33}
-            getImagePath={sequences[1].getImagePath}
-            objectFit="contain"
-            isPlaying={activeIndex === 0}
-            resetOnPlay
-            /* Only start loading the sequence on md */
-            preload={isMd ?? false}
-            className="pointer-events-none translate-y-[-3%] scale-[1.3] max-md:hidden"
+    <div className="not-prose @container">
+      <div className="grid grid-cols-1 gap-2 @md:gap-4 @xl:grid-cols-2 @3xl:grid-cols-3">
+        <CategoryCardLink
+          href="/components"
+          onMouseEnter={() => setActiveIndex(0)}
+          onMouseLeave={() => setActiveIndex(-1)}
+          onFocus={() => setActiveIndex(0)}
+          onBlur={() => setActiveIndex(-1)}
+          className="overflow-visible"
+        >
+          <CategoryCardLinkHeader
+            label="Components"
+            icon={<CubeIcon />}
+            count={counts.components}
           />
-          <Image
-            className="object-contain md:hidden"
-            src={sequences[1].getImagePath(18)}
-            alt={sequences[1].name}
-            sizes="50vw"
-            fill
-          />
-        </CategoryCardLinkSplash>
-      </CategoryCardLink>
+          <CategoryCardLinkSplash className="relative overflow-visible">
+            <CanvasSequence
+              frameCount={sequences[1].frameCount}
+              frameDuration={33}
+              getImagePath={sequences[1].getImagePath}
+              objectFit="contain"
+              isPlaying={activeIndex === 0}
+              resetOnPlay
+              /* Only start loading the sequence on md */
+              preload={isMd ?? false}
+              className="pointer-events-none translate-y-[-3%] scale-[1.3] max-md:hidden"
+            />
+            <Image
+              className="object-contain md:hidden"
+              src={sequences[1].getImagePath(18)}
+              alt={sequences[1].name}
+              sizes="50vw"
+              fill
+            />
+          </CategoryCardLinkSplash>
+        </CategoryCardLink>
 
-      <CategoryCardLink
-        href="/toolbox"
-        onMouseEnter={() => setActiveIndex(1)}
-        onMouseLeave={() => setActiveIndex(-1)}
-        onFocus={() => setActiveIndex(1)}
-        onBlur={() => setActiveIndex(-1)}
-        className="overflow-visible"
-      >
-        <CategoryCardLinkHeader
-          label="Toolbox"
-          icon={<TerminalWithCursorIcon />}
-          count={counts.toolbox}
-        />
-        <CategoryCardLinkSplash className="relative overflow-visible">
-          <CanvasSequence
-            frameCount={sequences[2].frameCount}
-            frameDuration={33}
-            getImagePath={sequences[2].getImagePath}
-            objectFit="contain"
-            isPlaying={activeIndex === 1}
-            resetOnPlay
-            /* Only start loading the sequence on md */
-            preload={isMd ?? false}
-            className="pointer-events-none scale-[1.3] max-md:hidden"
+        <CategoryCardLink
+          href="/toolbox"
+          onMouseEnter={() => setActiveIndex(1)}
+          onMouseLeave={() => setActiveIndex(-1)}
+          onFocus={() => setActiveIndex(1)}
+          onBlur={() => setActiveIndex(-1)}
+          className="overflow-visible"
+        >
+          <CategoryCardLinkHeader
+            label="Toolbox"
+            icon={<TerminalWithCursorIcon />}
+            count={counts.toolbox}
           />
-          <Image
-            className="object-contain md:hidden"
-            src={sequences[2].getImagePath(18)}
-            alt={sequences[2].name}
-            sizes="50vw"
-            fill
-          />
-        </CategoryCardLinkSplash>
-      </CategoryCardLink>
+          <CategoryCardLinkSplash className="relative overflow-visible">
+            <CanvasSequence
+              frameCount={sequences[2].frameCount}
+              frameDuration={33}
+              getImagePath={sequences[2].getImagePath}
+              objectFit="contain"
+              isPlaying={activeIndex === 1}
+              resetOnPlay
+              /* Only start loading the sequence on md */
+              preload={isMd ?? false}
+              className="pointer-events-none scale-[1.3] max-md:hidden"
+            />
+            <Image
+              className="object-contain md:hidden"
+              src={sequences[2].getImagePath(18)}
+              alt={sequences[2].name}
+              sizes="50vw"
+              fill
+            />
+          </CategoryCardLinkSplash>
+        </CategoryCardLink>
 
-      <CategoryCardLink
-        href="/logs"
-        onMouseEnter={() => setActiveIndex(2)}
-        onMouseLeave={() => setActiveIndex(-1)}
-        onFocus={() => setActiveIndex(2)}
-        onBlur={() => setActiveIndex(-1)}
-        className="overflow-visible"
-      >
-        <CategoryCardLinkHeader
-          label="Logs"
-          icon={<FileIcon />}
-          count={counts.logs}
-        />
-        <CategoryCardLinkSplash className="relative overflow-visible">
-          <CanvasSequence
-            frameCount={sequences[0].frameCount}
-            frameDuration={33}
-            getImagePath={sequences[0].getImagePath}
-            objectFit="contain"
-            isPlaying={activeIndex === 2}
-            resetOnPlay
-            /* Only start loading the sequence on md */
-            preload={isMd ?? false}
-            className="pointer-events-none translate-y-[-5%] scale-[1.3] max-md:hidden"
+        <CategoryCardLink
+          href="/logs"
+          onMouseEnter={() => setActiveIndex(2)}
+          onMouseLeave={() => setActiveIndex(-1)}
+          onFocus={() => setActiveIndex(2)}
+          onBlur={() => setActiveIndex(-1)}
+          className="overflow-visible"
+        >
+          <CategoryCardLinkHeader
+            label="Logs"
+            icon={<FileIcon />}
+            count={counts.logs}
           />
-          <Image
-            className="object-contain md:hidden"
-            src={sequences[0].getImagePath(18)}
-            alt={sequences[0].name}
-            sizes="50vw"
-            fill
-          />
-        </CategoryCardLinkSplash>
-      </CategoryCardLink>
+          <CategoryCardLinkSplash className="relative overflow-visible">
+            <CanvasSequence
+              frameCount={sequences[0].frameCount}
+              frameDuration={33}
+              getImagePath={sequences[0].getImagePath}
+              objectFit="contain"
+              isPlaying={activeIndex === 2}
+              resetOnPlay
+              /* Only start loading the sequence on md */
+              preload={isMd ?? false}
+              className="pointer-events-none translate-y-[-5%] scale-[1.3] max-md:hidden"
+            />
+            <Image
+              className="object-contain md:hidden"
+              src={sequences[0].getImagePath(18)}
+              alt={sequences[0].name}
+              sizes="50vw"
+              fill
+            />
+          </CategoryCardLinkSplash>
+        </CategoryCardLink>
+      </div>
     </div>
   )
 }

--- a/components/category-quick-links.tsx
+++ b/components/category-quick-links.tsx
@@ -73,7 +73,7 @@ export function CategoryQuickLinks() {
               className="object-contain md:hidden"
               src={sequences[1].getImagePath(18)}
               alt={sequences[1].name}
-              sizes="50vw"
+              sizes="100vw"
               fill
             />
           </CategoryCardLinkSplash>
@@ -108,7 +108,7 @@ export function CategoryQuickLinks() {
               className="object-contain md:hidden"
               src={sequences[2].getImagePath(18)}
               alt={sequences[2].name}
-              sizes="50vw"
+              sizes="100vw"
               fill
             />
           </CategoryCardLinkSplash>
@@ -143,7 +143,7 @@ export function CategoryQuickLinks() {
               className="object-contain md:hidden"
               src={sequences[0].getImagePath(18)}
               alt={sequences[0].name}
-              sizes="50vw"
+              sizes="100vw"
               fill
             />
           </CategoryCardLinkSplash>

--- a/components/icons/menu.tsx
+++ b/components/icons/menu.tsx
@@ -1,0 +1,16 @@
+import { SVGProps } from 'react'
+
+export const MenuIcon = (props: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path d="M3 5h18v2H3zm0 6h18v2H3zm0 6h18v2H3z"></path>
+    </svg>
+  )
+}

--- a/components/lab/lab-view-toggle.tsx
+++ b/components/lab/lab-view-toggle.tsx
@@ -65,7 +65,7 @@ export function LabViewToggle({
         aria-checked={view === 'list'}
         aria-label="List view"
         onClick={view === 'canvas' ? onToggle : undefined}
-        variant={view === 'list' ? 'accent' : 'muted'}
+        variant={view === 'list' ? 'muted' : 'accent'}
         size="icon-lg"
       >
         <GridIcon />
@@ -76,7 +76,7 @@ export function LabViewToggle({
         aria-checked={view === 'canvas'}
         aria-label="Canvas view"
         onClick={view === 'list' ? onToggle : undefined}
-        variant={view === 'list' ? 'muted' : 'accent'}
+        variant={view === 'list' ? 'accent' : 'muted'}
         size="icon-lg"
       >
         <InfinityIcon />

--- a/components/layout/mobile-nav-section.tsx
+++ b/components/layout/mobile-nav-section.tsx
@@ -44,13 +44,13 @@ export function MobileNavSection({
       {href ? (
         <div
           className={cn(
-            'flex w-full items-center gap-3 px-4 text-left transition-colors',
+            'flex w-full items-stretch gap-1 text-left transition-colors',
             isActive && 'bg-accent'
           )}
         >
           <Link
             href={href}
-            className="flex flex-1 items-center gap-3 py-4 text-left transition-colors"
+            className="h-mobile-header bg-secondary flex flex-1 items-center gap-3 pl-4 text-left transition-colors"
           >
             {headerContent}
           </Link>
@@ -58,7 +58,7 @@ export function MobileNavSection({
             type="button"
             aria-expanded={isOpen}
             aria-label={isOpen ? `Collapse ${label}` : `Expand ${label}`}
-            className="flex self-stretch items-center pl-4"
+            className="size-mobile-header bg-secondary flex aspect-square items-center self-stretch px-4"
             onClick={() => setIsOpen(!isOpen)}
           >
             {toggleIcon}
@@ -70,7 +70,7 @@ export function MobileNavSection({
           aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
           className={cn(
-            'flex w-full items-center gap-3 px-4 py-4 text-left transition-colors',
+            'bg-secondary flex h-full w-full items-center gap-3 px-4 text-left transition-colors',
             isActive && 'bg-accent'
           )}
         >

--- a/components/layout/mobile-nav-section.tsx
+++ b/components/layout/mobile-nav-section.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import * as React from 'react'
+import Link from 'next/link'
+import { Minus, Plus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+type MobileNavSectionProps = {
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>
+  label: string
+  href?: string
+  isActive?: boolean
+  defaultOpen?: boolean
+  children: React.ReactNode
+}
+
+export function MobileNavSection({
+  icon: Icon,
+  label,
+  href,
+  isActive = false,
+  defaultOpen = false,
+  children,
+}: MobileNavSectionProps) {
+  const [isOpen, setIsOpen] = React.useState(defaultOpen)
+
+  const headerContent = (
+    <>
+      <Icon className="size-5" />
+      <span className="font-mono text-xs font-medium tracking-wide uppercase">
+        {label}
+      </span>
+    </>
+  )
+
+  const toggleIcon = isOpen ? (
+    <Minus className="text-muted-foreground size-4" />
+  ) : (
+    <Plus className="text-muted-foreground size-4" />
+  )
+
+  return (
+    <div className="relative">
+      {href ? (
+        <div
+          className={cn(
+            'flex w-full items-center gap-3 px-4 text-left transition-colors',
+            isActive && 'bg-accent'
+          )}
+        >
+          <Link
+            href={href}
+            className="flex flex-1 items-center gap-3 py-4 text-left transition-colors"
+          >
+            {headerContent}
+          </Link>
+          <button
+            type="button"
+            aria-expanded={isOpen}
+            aria-label={isOpen ? `Collapse ${label}` : `Expand ${label}`}
+            className="flex self-stretch items-center pl-4"
+            onClick={() => setIsOpen(!isOpen)}
+          >
+            {toggleIcon}
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          onClick={() => setIsOpen(!isOpen)}
+          className={cn(
+            'flex w-full items-center gap-3 px-4 py-4 text-left transition-colors',
+            isActive && 'bg-accent'
+          )}
+        >
+          {headerContent}
+          <span className="ml-auto">{toggleIcon}</span>
+        </button>
+      )}
+
+      {isOpen && <div className="bg-accent/50 flex flex-col">{children}</div>}
+    </div>
+  )
+}

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -259,7 +259,7 @@ function MobileMenuContent({
       {/* Menu content */}
       <div className="bg-background relative">
         {/* Navigation sections */}
-        <nav className="flex flex-col">
+        <nav className="bg-background flex flex-col gap-1 py-1">
           {folders.map((folder, index) => (
             <MobileMenuSection
               key={folder.$id ?? index}
@@ -335,9 +335,7 @@ function MobileMenuSection({ folder, itemMeta = {} }: MobileMenuSectionProps) {
               />
             )}
             <span className="truncate">{child.name}</span>
-            {meta.badge && (
-              <MetaBadge type={meta.badge} className="ml-auto" />
-            )}
+            {meta.badge && <MetaBadge type={meta.badge} className="ml-auto" />}
           </Link>
         )
       })}
@@ -391,7 +389,7 @@ function MobileThemeToggle() {
   const { theme, setTheme } = useTheme()
 
   return (
-    <div className="bg-accent/50 pt-10">
+    <div className="bg-accent/50 md:pt-10">
       <div className="bg-background grid gap-y-4 pt-4">
         <p className="text-muted-foreground/80 px-4 font-mono text-xs font-medium tracking-wide uppercase">
           Theme

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { Command } from 'cmdk'
 import type * as PageTree from 'fumadocs-core/page-tree'
-import { Minus, Plus } from 'lucide-react'
 import CaretDownIcon from '@/components/icons/caret-down'
 import { cn } from '@/lib/utils'
 import { Logo } from '../logos'
@@ -24,6 +23,8 @@ import { useSearch, type SearchResult } from '@/hooks/use-search'
 import { ThemePreview, themes } from './theme-toggle'
 import { useTheme } from 'next-themes'
 import { useCallback } from 'react'
+import { MenuIcon } from '../icons/menu'
+import { MobileNavSection } from './mobile-nav-section'
 
 /* -------------------------------------------------------------------------------------------------
  * Types
@@ -68,7 +69,8 @@ export function MobileNav({
   const router = useRouter()
   const inputRef = React.useRef<HTMLInputElement>(null)
   const [state, setState] = React.useState<MobileNavState>('closed')
-  const { query, setQuery, results, resultsForQuery, hasResults, isEmpty } = useSearch()
+  const { query, setQuery, results, resultsForQuery, hasResults, isEmpty } =
+    useSearch()
 
   // Close menu on navigation
   React.useEffect(() => {
@@ -188,7 +190,7 @@ export function MobileNav({
           className="bg-muted flex aspect-square h-full shrink-0 items-center justify-center"
         >
           {state === 'closed' ? (
-            <div className="bg-muted-foreground size-3" />
+            <MenuIcon className="text-muted-foreground size-6" />
           ) : (
             <span className="font-mono text-xs tracking-wide uppercase">
               ESC
@@ -287,7 +289,6 @@ type MobileMenuSectionProps = {
 }
 
 function MobileMenuSection({ folder, itemMeta = {} }: MobileMenuSectionProps) {
-  const [isOpen, setIsOpen] = React.useState(false)
   const pathname = usePathname()
 
   const folderName =
@@ -298,68 +299,49 @@ function MobileMenuSection({ folder, itemMeta = {} }: MobileMenuSectionProps) {
   const isActive = pathname.startsWith(`/${sectionId}`)
 
   return (
-    <div className="">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className={cn(
-          'flex w-full items-center gap-3 px-4 py-4 text-left transition-colors',
-          isActive && 'bg-accent'
-        )}
-      >
-        <Icon className="size-5" />
-        <span className="font-mono text-xs font-medium tracking-wide uppercase">
-          {folder.name}
-        </span>
-        <span className="ml-auto">
-          {isOpen ? (
-            <Minus className="text-muted-foreground size-4" />
-          ) : (
-            <Plus className="text-muted-foreground size-4" />
-          )}
-        </span>
-      </button>
+    <MobileNavSection
+      icon={Icon}
+      label={
+        typeof folder.name === 'string' ? folder.name : String(folder.name)
+      }
+      href={`/${sectionId}`}
+      isActive={isActive}
+    >
+      {folder.children.map((child) => {
+        if (child.type !== 'page') return null
+        const meta = itemMeta[child.url] ?? {}
+        const isItemActive = pathname === child.url
 
-      {isOpen && (
-        <div className="bg-accent/50 flex flex-col">
-          {folder.children.map((child) => {
-            if (child.type === 'page') {
-              const meta = itemMeta[child.url] ?? {}
-              const isItemActive = pathname === child.url
-
-              return (
-                <Link
-                  key={child.url}
-                  href={child.url}
-                  className={cn(
-                    'flex items-center gap-2 py-2 pr-4 pl-12 font-mono text-xs tracking-wide uppercase transition-colors',
-                    isItemActive
-                      ? 'text-foreground bg-accent font-medium'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                  )}
-                >
-                  {meta.dot && (
-                    <span
-                      className={cn(
-                        'size-2 shrink-0 rounded-full',
-                        meta.dot === 'red' && 'bg-red-500',
-                        meta.dot === 'blue' && 'bg-blue-500',
-                        meta.dot === 'green' && 'bg-green-500',
-                        meta.dot === 'yellow' && 'bg-yellow-500'
-                      )}
-                    />
-                  )}
-                  <span className="truncate">{child.name}</span>
-                  {meta.badge && (
-                    <MetaBadge type={meta.badge} className="ml-auto" />
-                  )}
-                </Link>
-              )
-            }
-            return null
-          })}
-        </div>
-      )}
-    </div>
+        return (
+          <Link
+            key={child.url}
+            href={child.url}
+            className={cn(
+              'flex items-center gap-2 py-2 pr-4 pl-12 font-mono text-xs tracking-wide uppercase transition-colors',
+              isItemActive
+                ? 'text-foreground bg-accent font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+            )}
+          >
+            {meta.dot && (
+              <span
+                className={cn(
+                  'size-2 shrink-0 rounded-full',
+                  meta.dot === 'red' && 'bg-red-500',
+                  meta.dot === 'blue' && 'bg-blue-500',
+                  meta.dot === 'green' && 'bg-green-500',
+                  meta.dot === 'yellow' && 'bg-yellow-500'
+                )}
+              />
+            )}
+            <span className="truncate">{child.name}</span>
+            {meta.badge && (
+              <MetaBadge type={meta.badge} className="ml-auto" />
+            )}
+          </Link>
+        )
+      })}
+    </MobileNavSection>
   )
 }
 
@@ -368,56 +350,36 @@ function MobileMenuSection({ folder, itemMeta = {} }: MobileMenuSectionProps) {
  * -------------------------------------------------------------------------------------------------*/
 
 function MobileLabSection({ experiments }: { experiments: Experiment[] }) {
-  const [isOpen, setIsOpen] = React.useState(false)
   const pathname = usePathname()
   const isActive = pathname.startsWith('/lab')
 
   return (
-    <div>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className={cn(
-          'flex w-full items-center gap-3 px-4 py-4 text-left transition-colors',
-          isActive && 'bg-accent'
-        )}
-      >
-        <FlaskIcon className="size-5" />
-        <span className="font-mono text-xs font-medium tracking-wide uppercase">
-          Lab
-        </span>
-        <span className="ml-auto">
-          {isOpen ? (
-            <Minus className="text-muted-foreground size-4" />
-          ) : (
-            <Plus className="text-muted-foreground size-4" />
-          )}
-        </span>
-      </button>
+    <MobileNavSection
+      icon={FlaskIcon}
+      label="Lab"
+      href="/lab"
+      isActive={isActive}
+    >
+      {experiments.map((experiment) => {
+        const url = `/lab/${experiment.slug}`
+        const isItemActive = pathname === url
 
-      {isOpen && (
-        <div className="bg-accent/50 flex flex-col">
-          {experiments.map((experiment) => {
-            const url = `/lab/${experiment.slug}`
-            const isItemActive = pathname === url
-
-            return (
-              <Link
-                key={experiment.slug}
-                href={url}
-                className={cn(
-                  'flex items-center gap-2 py-2 pr-4 pl-12 font-mono text-xs tracking-wide uppercase transition-colors',
-                  isItemActive
-                    ? 'text-foreground bg-accent font-medium'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-accent'
-                )}
-              >
-                <span className="truncate">{experiment.title}</span>
-              </Link>
-            )
-          })}
-        </div>
-      )}
-    </div>
+        return (
+          <Link
+            key={experiment.slug}
+            href={url}
+            className={cn(
+              'flex items-center gap-2 py-2 pr-4 pl-12 font-mono text-xs tracking-wide uppercase transition-colors',
+              isItemActive
+                ? 'text-foreground bg-accent font-medium'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+            )}
+          >
+            <span className="truncate">{experiment.title}</span>
+          </Link>
+        )
+      })}
+    </MobileNavSection>
   )
 }
 
@@ -511,7 +473,12 @@ function MobileSearchContent({
           className="sr-only"
         />
         {hasResults && (
-          <SearchResults key={resultsForQuery} results={results} query={query} onSelect={onSelect} />
+          <SearchResults
+            key={resultsForQuery}
+            results={results}
+            query={query}
+            onSelect={onSelect}
+          />
         )}
         {isEmpty && <NoResults query={query} />}
         {!hasResults && !isEmpty && (

--- a/components/layout/sidebar/section.tsx
+++ b/components/layout/sidebar/section.tsx
@@ -349,6 +349,13 @@ export function SidebarSection({
   }
 
   // For other sections (Logs), render with collapsible header
+
+  const sortedLogs = (() => {
+    if (sectionId === 'logs') {
+      return folder.children.toReversed()
+    }
+    return folder.children
+  })()
   return (
     <div className="flex flex-col">
       <button
@@ -376,7 +383,7 @@ export function SidebarSection({
       {isOpen && (
         <>
           <div className="border-border ml-4 flex flex-col border-l-2">
-            {folder.children.map((child) => {
+            {sortedLogs.map((child) => {
               if (child.type === 'page') {
                 const itemMeta = meta[child.url] ?? {}
                 if (itemMeta.hidden) return null

--- a/components/toc/clerk.tsx
+++ b/components/toc/clerk.tsx
@@ -167,7 +167,7 @@ function TOCItem({
           insetInlineStart: offset,
         }}
       />
-      <span className="line-clamp-1 truncate">{item.title}</span>
+      <span className="line-clamp-1">{item.title}</span>
     </Primitive.TOCItem>
   )
 }

--- a/components/toc/clerk.tsx
+++ b/components/toc/clerk.tsx
@@ -167,7 +167,7 @@ function TOCItem({
           insetInlineStart: offset,
         }}
       />
-      {item.title}
+      <span className="line-clamp-1 truncate">{item.title}</span>
     </Primitive.TOCItem>
   )
 }


### PR DESCRIPTION
## Summary

- **Mobile nav**: tapping a category header (Components, Toolbox, Logs, Lab) now navigates to its index page. The expand/collapse toggle moved to its own button on the right. Extracted the pattern into a reusable `MobileNavSection` component.
- **Category quick links**: swapped viewport breakpoints for container queries (`@container` / `@xl` / `@3xl`) so the grid reflows based on its container instead of the viewport.
- **TOC**: long titles now truncate to one line (`line-clamp-1 truncate`) to keep the aside tidy.
- Added `MenuIcon` for the mobile hamburger button.

## Test plan

- [ ] On mobile, open the nav and tap the Components/Toolbox/Logs/Lab header → lands on the section index page.
- [ ] Tap the +/- button on the right → expands/collapses children without navigating.
- [ ] Resize the category quick-links container (e.g. sidebar open/closed) → grid reflows 1 → 2 → 3 columns based on container width.
- [ ] Load a page with a long TOC heading → the item truncates instead of wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves the mobile navigation UX by making category headers tappable index links with a separate collapse toggle, migrates the category quick-links grid from viewport breakpoints to container queries, and adds single-line truncation to TOC items. The changes are well-scoped and the `MobileNavSection` extraction is clean and accessible.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 style/optimization findings remain.

No logic errors or runtime defects found. The two inline comments are minor: a slightly undersized image hint after the grid change, and a redundant CSS utility pair. Neither affects correctness.

components/category-quick-links.tsx — the sizes attribute on the static Image fallbacks should be updated to reflect the new single-column mobile default.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/category-quick-links.tsx | Grid columns swapped from viewport breakpoints to container queries (@xl/@3xl); image visibility modifiers remain viewport-based (intentional), but sizes="50vw" is now incorrect for the new 1-column mobile default. |
| components/layout/mobile-nav-section.tsx | New reusable MobileNavSection component cleanly extracted from MobileMenuSection/MobileLabSection; accessible toggle button with aria-expanded/aria-label. |
| components/layout/mobile-nav.tsx | MobileMenuSection and MobileLabSection refactored to use MobileNavSection; added MenuIcon for the hamburger button; code-format improvements only. |
| components/toc/clerk.tsx | TOC item title wrapped in a span with line-clamp-1 truncate to prevent multi-line overflow; change is minimal and correct. |
| components/icons/menu.tsx | New MenuIcon SVG component for the mobile hamburger button; follows existing icon patterns. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: components/category-quick-links.tsx
Line: 72-78

Comment:
**`sizes` hint now understates image width on mobile**

Previously the grid was `grid-cols-2` on mobile, so each image occupied ~50% of the viewport and `sizes="50vw"` was accurate. The new grid starts at `grid-cols-1`, so on a mobile viewport the static `Image` fills the full container width — `50vw` causes the browser to download a smaller-than-needed image. Each of the three cards has this same attribute.

```suggestion
              sizes="100vw"
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: components/toc/clerk.tsx
Line: 170

Comment:
**Redundant truncation utilities**

`line-clamp-1` already constrains content to one line with an ellipsis (via `-webkit-line-clamp`), and `truncate` does the same via `white-space: nowrap` + `text-overflow: ellipsis`. Using both works in practice but is redundant — `line-clamp-1` alone is sufficient (and more reliable for inline elements since it explicitly sets `display: -webkit-box`).

```suggestion
      <span className="line-clamp-1">{item.title}</span>
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["many fixes"](https://github.com/joyco-studio/hub/commit/90bb4bb514ee176b00b4da3522c924ec29ab4f1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28281026)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->