### PR TITLE
Exclude registry.json from download tracking

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -5,7 +5,7 @@ import { trackRegistryDownload } from '@/lib/track'
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
-  if (pathname.startsWith('/r/')) {
+  if (pathname.startsWith('/r/') && pathname !== '/r/registry.json') {
     await trackRegistryDownload(request)
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,10 +2,14 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { trackRegistryDownload } from '@/lib/track'
 
+// Matches component JSONs like /r/button.json, excluding the /r/registry.json
+// catalog index that shadcn fetches on init/add.
+const REGISTRY_ITEM_PATH = /^\/r\/(?!registry\.json$)[\w-]+\.json$/
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
-  if (pathname.startsWith('/r/') && pathname !== '/r/registry.json') {
+  if (REGISTRY_ITEM_PATH.test(pathname)) {
     await trackRegistryDownload(request)
   }
 


### PR DESCRIPTION
## Summary
Updated the download tracking logic to exclude the `/r/registry.json` endpoint from being tracked, preventing unnecessary tracking events for registry metadata requests.

## Changes
- Modified the pathname check in the `proxy` function to explicitly exclude `/r/registry.json` from triggering the `trackRegistryDownload` function
- The condition now verifies both that the path starts with `/r/` AND that it is not the registry.json endpoint

## Details
This change ensures that only actual package downloads are tracked, while metadata requests to the registry index are filtered out. This provides more accurate download metrics by excluding non-package requests.

https://claude.ai/code/session_01LRkvGiCK523vNkHzAhkmM1

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR excludes the `/r/registry.json` metadata endpoint from `trackRegistryDownload` calls. Without this guard, every fetch of the registry index would fire a `registry:registry` download event (the `trackDownload` helper strips both the `/r/` prefix and `.json` suffix), inflating metrics with non-package requests. The one-line fix is correct and sufficient.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line guard with no side effects or regressions.

The change is a targeted one-line fix that correctly excludes a known false-positive from download tracking. No logic errors, no security implications, and the exclusion condition is precise.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| proxy.ts | Adds an exclusion for `/r/registry.json` from download tracking; logic is correct and the condition works as intended since `nextUrl.pathname` never includes query strings. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use regex allowlist for regist..."](https://github.com/joyco-studio/hub/commit/cd7b5458a8d22e7d22b2259dce2160703ef35faa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28530264)</sub>

<!-- /greptile_comment -->