### PR TITLE
fix: cap TOC scroll area height and hide scrollbar

### DIFF
--- a/app/(registry)/[[...slug]]/page.tsx
+++ b/app/(registry)/[[...slug]]/page.tsx
@@ -221,6 +221,14 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
         {/* Desktop TOC */}
         {hasToc && (
           <TOC
+            className={cn(
+              !(
+                page.data.maintainers.length > 0 ||
+                downloadStats ||
+                !!pageViews ||
+                isLog
+              ) && 'slot-[toc-scroll-area]:max-h-[75vh]'
+            )}
             footer={
               <>
                 {isLog && <Author author={page.data.author} />}

--- a/app/(registry)/[[...slug]]/page.tsx
+++ b/app/(registry)/[[...slug]]/page.tsx
@@ -221,14 +221,6 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
         {/* Desktop TOC */}
         {hasToc && (
           <TOC
-            className={cn(
-              !(
-                page.data.maintainers.length > 0 ||
-                downloadStats ||
-                !!pageViews ||
-                isLog
-              ) && 'slot-[toc-scroll-area]:max-h-[75vh]'
-            )}
             footer={
               <>
                 {isLog && <Author author={page.data.author} />}

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -2,6 +2,7 @@
 @import 'fumadocs-ui/css/shadcn.css';
 @import 'fumadocs-ui/css/preset.css';
 @import 'tw-animate-css';
+@plugin './slot.ts';
 @import 'tailwindcss-better-gradient';
 @import './shiki.css' layer(components);
 @import './prose.css' layer(utilities);
@@ -165,65 +166,69 @@ html.terminal canvas {
  * Note: On macOS, "Show scroll bars: Always" in System Settings
  * is required for full CSS control over scrollbar appearance.
  * The transparent border trick helps force custom rendering.
+ *
+ * Wrapped in @layer base so the `scrollbar-none` utility can override.
  */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--accent) transparent;
-}
+@layer base {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--accent) transparent;
+  }
 
-*::-webkit-scrollbar {
-  -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
-  background-color: transparent;
-}
+  *::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 12px;
+    height: 12px;
+    background-color: transparent;
+  }
 
-*::-webkit-scrollbar-track {
-  -webkit-appearance: none;
-  background-color: transparent;
-  border-radius: 0;
-}
+  *::-webkit-scrollbar-track {
+    -webkit-appearance: none;
+    background-color: transparent;
+    border-radius: 0;
+  }
 
-*::-webkit-scrollbar-thumb {
-  -webkit-appearance: none;
-  background-color: var(--accent);
-  border-radius: 0;
-  /* Transparent border trick - helps force custom scrollbar on macOS */
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
+  *::-webkit-scrollbar-thumb {
+    -webkit-appearance: none;
+    background-color: var(--accent);
+    border-radius: 0;
+    /* Transparent border trick - helps force custom scrollbar on macOS */
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
 
-*::-webkit-scrollbar-thumb:hover {
-  background-color: color-mix(in oklab, var(--accent) 80%, var(--foreground));
-}
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--accent) 80%, var(--foreground));
+  }
 
-*::-webkit-scrollbar-corner {
-  background-color: transparent;
-}
+  *::-webkit-scrollbar-corner {
+    background-color: transparent;
+  }
 
-/* Code block specific scrollbar - no border trick for cleaner look */
-pre::-webkit-scrollbar,
-code::-webkit-scrollbar {
-  height: 8px;
-  width: 8px;
-  background: transparent;
-}
+  /* Code block specific scrollbar - no border trick for cleaner look */
+  pre::-webkit-scrollbar,
+  code::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+    background: transparent;
+  }
 
-pre::-webkit-scrollbar-track,
-code::-webkit-scrollbar-track {
-  background: transparent;
-}
+  pre::-webkit-scrollbar-track,
+  code::-webkit-scrollbar-track {
+    background: transparent;
+  }
 
-pre::-webkit-scrollbar-thumb,
-code::-webkit-scrollbar-thumb {
-  background: var(--accent);
-  border-radius: 0 !important;
-  border: none;
-}
+  pre::-webkit-scrollbar-thumb,
+  code::-webkit-scrollbar-thumb {
+    background: var(--accent);
+    border-radius: 0 !important;
+    border: none;
+  }
 
-pre::-webkit-scrollbar-thumb:hover,
-code::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in oklab, var(--accent) 80%, var(--foreground));
+  pre::-webkit-scrollbar-thumb:hover,
+  code::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklab, var(--accent) 80%, var(--foreground));
+  }
 }
 
 @layer components {

--- a/app/styles/slot.ts
+++ b/app/styles/slot.ts
@@ -1,0 +1,5 @@
+import type { PluginAPI } from 'tailwindcss/plugin'
+
+export default function ({ matchVariant }: PluginAPI) {
+  matchVariant('slot', (value: string) => `& [data-slot="${value}"]`)
+}

--- a/components/layout/toc.tsx
+++ b/components/layout/toc.tsx
@@ -31,7 +31,7 @@ export function TOC({ header, footer, className }: ClerkTOCProps) {
       )}
     >
       <div className="flex h-full max-h-screen w-(--fd-toc-width) flex-col gap-1">
-        <div className="bg-muted flex min-h-0 flex-col px-6 py-4 font-mono uppercase">
+        <div className="bg-muted flex max-h-[77vh] min-h-0 flex-col px-6 py-4 font-mono uppercase">
           {header}
           <h3
             id="toc-title"
@@ -40,10 +40,7 @@ export function TOC({ header, footer, className }: ClerkTOCProps) {
             <TextScanIcon className="size-4" />
             <span>On this page</span>
           </h3>
-          <TOCScrollArea
-            data-slot="toc-scroll-area"
-            className="scrollbar-none max-h-[75vh]"
-          >
+          <TOCScrollArea data-slot="toc-scroll-area" className="scrollbar-none">
             <TOCItems className="[&_a]:text-xs" />
           </TOCScrollArea>
         </div>

--- a/components/layout/toc.tsx
+++ b/components/layout/toc.tsx
@@ -30,8 +30,8 @@ export function TOC({ header, footer, className }: ClerkTOCProps) {
         className
       )}
     >
-      <div className="flex h-full w-(--fd-toc-width) flex-col gap-1">
-        <div className="bg-muted px-6 py-4 font-mono uppercase">
+      <div className="flex h-full max-h-screen w-(--fd-toc-width) flex-col gap-1">
+        <div className="bg-muted flex min-h-0 flex-col px-6 py-4 font-mono uppercase">
           {header}
           <h3
             id="toc-title"
@@ -40,7 +40,10 @@ export function TOC({ header, footer, className }: ClerkTOCProps) {
             <TextScanIcon className="size-4" />
             <span>On this page</span>
           </h3>
-          <TOCScrollArea>
+          <TOCScrollArea
+            data-slot="toc-scroll-area"
+            className="scrollbar-none max-h-[75vh]"
+          >
             <TOCItems className="[&_a]:text-xs" />
           </TOCScrollArea>
         </div>

--- a/components/toc/clerk.tsx
+++ b/components/toc/clerk.tsx
@@ -167,7 +167,9 @@ function TOCItem({
           insetInlineStart: offset,
         }}
       />
-      <span className="line-clamp-1">{item.title}</span>
+      <span className="not-prose [&_code]:bg-secondary line-clamp-1">
+        {item.title}
+      </span>
     </Primitive.TOCItem>
   )
 }

--- a/components/toc/index.tsx
+++ b/components/toc/index.tsx
@@ -40,7 +40,7 @@ export function TOCScrollArea({ ref, className, ...props }: ComponentProps<'div'
     <div
       ref={mergeRefs(viewRef, ref)}
       className={cn(
-        'relative min-h-0 text-sm ms-px overflow-auto [scrollbar-width:none] mask-[linear-gradient(to_bottom,transparent,white_16px,white_calc(100%-16px),transparent)] py-3',
+        'relative min-h-0 text-sm ms-px overflow-auto scrollbar-none mask-[linear-gradient(to_bottom,transparent,white_16px,white_calc(100%-16px),transparent)] py-3',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Fix the TOC so the scroll area never pushes the footer (Author / Views / Downloads) off the viewport
- Cap the `bg-muted` TOC wrapper at `max-h-[77vh]` and let the scroll area fill the remaining space under the title
- Move the global custom-scrollbar rules into `@layer base` so the `scrollbar-none` utility can override them, and use it on the TOC scroll area so the scrollbar is actually hidden
- Render inline `<code>` inside TOC item titles with `not-prose` + `bg-secondary` so prose styles don't bleed into the sidebar
- Add a small `slot.ts` Tailwind plugin that exposes a `slot-[name]` variant targeting `[data-slot="name"]`

## Test plan
- [ ] Page with a very long TOC: scroll area scrolls, footer (author/views) stays visible, no blank space
- [ ] Page with a short TOC: wrapper shrinks to content, no extra space
- [ ] Page with inline `code` in a heading: code pill renders correctly inside the TOC
- [ ] Scrollbar is not visible on the TOC in Chrome / Safari / Firefox
- [ ] Other scroll containers still show the custom thin scrollbar
