### PR TITLE
fix: prevent theme flash on refresh (head-injected theme class)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -71,10 +71,24 @@ export default function Layout({ children }: LayoutProps<'/'>) {
           dangerouslySetInnerHTML={{
             __html: `
               try {
+                var themes = ['light', 'dark', 'radio', 'terminal']
+                var stored = localStorage.theme
+                var theme
+                if (stored === 'system') {
+                  theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+                } else if (themes.indexOf(stored) !== -1) {
+                  theme = stored
+                } else {
+                  theme = 'dark'
+                }
+                document.documentElement.classList.add(theme)
+                document.documentElement.style.colorScheme = theme === 'light' || theme === 'radio' ? 'light' : 'dark'
                 if (localStorage.layout) {
                   document.documentElement.classList.add('layout-' + localStorage.layout)
                 }
-              } catch (_) {}
+              } catch (_) {
+                document.documentElement.classList.add('dark')
+              }
             `,
           }}
         />
@@ -85,6 +99,8 @@ export default function Layout({ children }: LayoutProps<'/'>) {
             enabled: false,
           }}
           theme={{
+            // If you change `themes` or `defaultTheme`, also update the
+            // anti-flash script in <head> above so SSR and the script agree.
             themes: ['light', 'dark', 'radio', 'terminal'],
             defaultTheme: 'dark',
           }}


### PR DESCRIPTION
## What this does

Eliminates the brief flash of light-mode content that some users see on refresh when the site is set to dark (or any non-light theme).

The fix is a small inline `<script>` placed in `<head>` of the root layout. It runs synchronously before any CSS paints and:

1. Reads `localStorage.theme` (next-themes' default storage key — Fumadocs uses defaults).
2. If the value is `system`, resolves it against `prefers-color-scheme`.
3. If the value is one of our registered themes (`light`, `dark`, `radio`, `terminal`), uses it.
4. Otherwise falls back to `dark` (matches `RootProvider`'s `defaultTheme`).
5. Adds the resolved class to `<html>` and sets `style.colorScheme` so native UI (scrollbars, form controls) matches.
6. Wraps everything in `try/catch` and falls back to `dark` on error.

The existing `localStorage.layout` snippet was kept and merged into the same script.

## Why this is needed (and why it only happens in prod)

Fumadocs' `RootProvider` is rendered inside `<body>`. next-themes' built-in class-setting script is therefore emitted in body, after `<head>` CSS has already started applying. Under streaming SSR with real network latency, the browser can paint early body chunks with `:root` (light) variables before reaching that script — producing the flash.

On `localhost` the whole document arrives in a single tick, so the body-positioned script effectively runs before any paint and the issue is invisible.

A short comment was added next to the `RootProvider` `themes` config reminding future contributors that the head script needs to stay in sync with the `themes` array and `defaultTheme`.

## Files changed

- `app/layout.tsx` — expanded the existing `<head>` script and added the sync-reminder comment.

## How to test

Localhost won't reliably reproduce the original bug, so verification needs prod-like conditions.

### Reproduce-the-bug check (must pass)
- [ ] Deploy this branch to a preview URL (or run `pnpm build && pnpm start`).
- [ ] DevTools → Network → throttle to **Slow 3G**, disable cache.
- [ ] Hard-refresh several routes, especially pages with iframe demos (component preview pages).
- [ ] Confirm: no white/light flash before the page renders dark.

### Theme-switch behavior (must pass)
- [ ] Toggle to `light` via the theme switcher → refresh → page renders directly in light, no flash.
- [ ] Repeat for `radio` and `terminal`.
- [ ] Set `localStorage.theme = 'system'` manually, refresh under both light and dark OS preferences → page matches OS preference on first paint.
- [ ] Clear `localStorage.theme` entirely, refresh → page renders in dark immediately.

### Regression checks
- [ ] `localStorage.layout` still applies its `layout-*` class on `<html>` (the original snippet's behavior is preserved).
- [ ] No hydration warnings in the console for `<html>` (we already use `suppressHydrationWarning`, but worth a glance).
- [ ] Theme toggle (`components/layout/theme-toggle.tsx`) still works — clicking it changes the class with no visual glitch.
- [ ] Mobile nav theme switch still works (`components/layout/mobile-nav.tsx`).
- [ ] Demo iframes (resizable preview, lab experiments) inherit the correct theme on first paint.

## Notes / follow-ups

- If we ever change the `themes` array or `defaultTheme` in `RootProvider`, the head script must be updated to match. The inline comment in `app/layout.tsx` flags this.
- Long-term, an alternative would be to make `:root` carry the dark variables (since `dark` is the default) and treat `.light` as the override. That would make the SSR baseline already correct without needing a head script. This PR takes the lower-risk route.

Generated with Claude Code

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a blocking inline script in `<head>` that reads `localStorage.theme`, resolves `system` preference via `matchMedia`, and stamps the correct theme class (plus `colorScheme`) onto `<html>` before any paint — closing the FOUC window that exists because `RootProvider` / `next-themes` lives in `<body>`. The fallback to `dark` and the `themes` array match `RootProvider`'s config, and the developer comment is a good guard against future drift.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is correct and well-scoped, with one minor P2 note about `colorScheme` consistency after live theme switches.

Only P2 findings present; implementation logic is sound, fallback is correct, and themes array is kept in sync with `RootProvider` config.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/layout.tsx | Adds a blocking inline `<head>` script that reads `localStorage.theme`, resolves `system` via `matchMedia`, applies the theme class and `colorScheme` style to `<html>` before first paint — eliminating the FOUC. Logic and fallback are correct; minor concern around `colorScheme` consistency after live theme switches for custom themes. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: app/layout.tsx
Line: 85

Comment:
**`colorScheme` inline style may diverge after live theme switches**

The head script sets `style.colorScheme` once on page load, but after a client-side theme change `next-themes` overwrites `style.colorScheme` with the raw theme name (e.g. `"radio"` or `"terminal"`), which are not valid `color-scheme` CSS values — so the browser ignores it and the inline style from this script effectively becomes stale. CSS rules like `.radio { color-scheme: light }` in the stylesheet would then govern the value correctly, but only if such rules exist. Worth verifying that the stylesheet covers `color-scheme` for `radio` and `terminal`, or consider removing the `style.colorScheme` assignment and relying purely on CSS so the behavior is consistent between first-load and live switches.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent theme flash by setting clas..."](https://github.com/joyco-studio/hub/commit/396733691231131d6d771b2fcc13567f904a9854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30080001)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->