### PR TITLE
Add typed-tiny-emitter

### DIFF
--- a/content/components/meta.json
+++ b/content/components/meta.json
@@ -22,6 +22,7 @@
     "scroll-area",
     "snake-game",
     "spritesheet-sequencer",
+    "typed-emitter",
     "typewriter"
   ]
 }

--- a/content/components/typed-emitter.mdx
+++ b/content/components/typed-emitter.mdx
@@ -1,0 +1,62 @@
+---
+title: Typed Emitter
+description: A thin typed wrapper around tiny-emitter. Subclasses pin an event-map type so on/once/emit are fully type-safe.
+maintainers: ['joyco-studio']
+docLinks:
+  - label: 'tiny-emitter'
+    href: 'https://github.com/scottcorgan/tiny-emitter'
+---
+
+## Installation
+
+```bash
+npx shadcn@latest add @joyco/typed-emitter
+```
+
+## Usage
+
+Extend `TypedEmitter` with an event map (`{ eventName: payloadType }`). Listeners and emits are checked against the map.
+
+```ts
+import { TypedEmitter } from '@/registry/lib/typed-emitter'
+
+type PlayerEvents = {
+  play: { time: number }
+  pause: void
+  seek: { from: number; to: number }
+}
+
+class Player extends TypedEmitter<PlayerEvents> {
+  start() {
+    this.emit('play', { time: 0 })
+  }
+
+  stop() {
+    this.emit('pause', undefined)
+  }
+}
+
+const player = new Player()
+
+const off = player.on('play', ({ time }) => {
+  console.log('playing from', time)
+})
+
+player.start()
+off() // unsubscribe
+```
+
+## API
+
+| Method  | Signature                                                           | Description                                                                                |
+| ------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `on`    | `(event, listener) => () => void`                                   | Subscribe to an event. Returns an unsubscribe function.                                    |
+| `once`  | `(event, listener) => void`                                         | Subscribe to a single firing of an event.                                                  |
+| `off`   | `(event, listener?) => void`                                        | Unsubscribe a specific listener, or all listeners for an event when `listener` is omitted. |
+| `emit`  | `(event, payload) => void`                                          | `protected` — emit an event from the subclass.                                             |
+
+## Notes
+
+- `emit` is `protected` on purpose — events are an implementation detail of the subclass, not part of its public surface. Consumers subscribe with `on`/`once`/`off` and let the class decide when to fire.
+- The unsubscribe function returned by `on` is the recommended way to clean up, particularly inside `useEffect`.
+- For events with no payload, type the value as `void` and pass `undefined` when emitting.

--- a/public/r/debug.json
+++ b/public/r/debug.json
@@ -7,6 +7,7 @@
   "dependencies": [
     "@tweakpane/core",
     "lodash.debounce",
+    "@types/lodash.debounce",
     "zustand",
     "tweakpane"
   ],

--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -305,6 +305,19 @@
       "registryDependencies": ["@joyco/button", "@joyco/kbd"]
     },
     {
+      "name": "typed-emitter",
+      "type": "registry:lib",
+      "title": "Typed Emitter",
+      "description": "A thin typed wrapper around tiny-emitter that lets subclasses pin an event-map type for fully typed on/emit.",
+      "files": [
+        {
+          "path": "registry/lib/typed-emitter.ts",
+          "type": "registry:lib"
+        }
+      ],
+      "dependencies": ["tiny-emitter"]
+    },
+    {
       "name": "canvas-2d",
       "type": "registry:component",
       "title": "Canvas 2D",
@@ -384,6 +397,7 @@
       "dependencies": [
         "@tweakpane/core",
         "lodash.debounce",
+        "@types/lodash.debounce",
         "zustand",
         "tweakpane"
       ]

--- a/public/r/typed-emitter.json
+++ b/public/r/typed-emitter.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "typed-emitter",
+  "type": "registry:lib",
+  "title": "Typed Emitter",
+  "description": "A thin typed wrapper around tiny-emitter that lets subclasses pin an event-map type for fully typed on/emit.",
+  "dependencies": [
+    "tiny-emitter"
+  ],
+  "files": [
+    {
+      "path": "registry/lib/typed-emitter.ts",
+      "content": "// @ts-expect-error: No types available for tiny-emitter\nimport { TinyEmitter } from 'tiny-emitter'\n\n/**\n * Thin typed wrapper around `tiny-emitter`. Subclasses pin an event-map type\n * (`{ eventName: payloadType }`) so `on`/`emit` are fully typed.\n */\nexport class TypedEmitter<EventMap extends Record<string, unknown>> {\n  private readonly emitter = new TinyEmitter()\n\n  on<K extends keyof EventMap & string>(\n    event: K,\n    listener: (payload: EventMap[K]) => void\n  ): () => void {\n    this.emitter.on(event, listener as (...args: unknown[]) => void)\n    return () => this.off(event, listener)\n  }\n\n  once<K extends keyof EventMap & string>(\n    event: K,\n    listener: (payload: EventMap[K]) => void\n  ): void {\n    this.emitter.once(event, listener as (...args: unknown[]) => void)\n  }\n\n  off<K extends keyof EventMap & string>(\n    event: K,\n    listener?: (payload: EventMap[K]) => void\n  ): void {\n    this.emitter.off(\n      event,\n      listener as ((...args: unknown[]) => void) | undefined\n    )\n  }\n\n  protected emit<K extends keyof EventMap & string>(\n    event: K,\n    payload: EventMap[K]\n  ): void {\n    this.emitter.emit(event, payload)\n  }\n}\n",
+      "type": "registry:lib"
+    }
+  ]
+}

--- a/registry.json
+++ b/registry.json
@@ -305,6 +305,19 @@
       "registryDependencies": ["@joyco/button", "@joyco/kbd"]
     },
     {
+      "name": "typed-emitter",
+      "type": "registry:lib",
+      "title": "Typed Emitter",
+      "description": "A thin typed wrapper around tiny-emitter that lets subclasses pin an event-map type for fully typed on/emit.",
+      "files": [
+        {
+          "path": "registry/lib/typed-emitter.ts",
+          "type": "registry:lib"
+        }
+      ],
+      "dependencies": ["tiny-emitter"]
+    },
+    {
       "name": "canvas-2d",
       "type": "registry:component",
       "title": "Canvas 2D",
@@ -384,6 +397,7 @@
       "dependencies": [
         "@tweakpane/core",
         "lodash.debounce",
+        "@types/lodash.debounce",
         "zustand",
         "tweakpane"
       ]

--- a/registry/lib/typed-emitter.ts
+++ b/registry/lib/typed-emitter.ts
@@ -1,0 +1,42 @@
+// @ts-expect-error: No types available for tiny-emitter
+import { TinyEmitter } from 'tiny-emitter'
+
+/**
+ * Thin typed wrapper around `tiny-emitter`. Subclasses pin an event-map type
+ * (`{ eventName: payloadType }`) so `on`/`emit` are fully typed.
+ */
+export class TypedEmitter<EventMap extends Record<string, unknown>> {
+  private readonly emitter = new TinyEmitter()
+
+  on<K extends keyof EventMap & string>(
+    event: K,
+    listener: (payload: EventMap[K]) => void
+  ): () => void {
+    this.emitter.on(event, listener as (...args: unknown[]) => void)
+    return () => this.off(event, listener)
+  }
+
+  once<K extends keyof EventMap & string>(
+    event: K,
+    listener: (payload: EventMap[K]) => void
+  ): void {
+    this.emitter.once(event, listener as (...args: unknown[]) => void)
+  }
+
+  off<K extends keyof EventMap & string>(
+    event: K,
+    listener?: (payload: EventMap[K]) => void
+  ): void {
+    this.emitter.off(
+      event,
+      listener as ((...args: unknown[]) => void) | undefined
+    )
+  }
+
+  protected emit<K extends keyof EventMap & string>(
+    event: K,
+    payload: EventMap[K]
+  ): void {
+    this.emitter.emit(event, payload)
+  }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new `TypedEmitter` registry lib — a thin typed wrapper around `tiny-emitter` that lets subclasses pin an event-map type for fully typed `on`/`emit` — and fixes a missing `@types/lodash.debounce` dependency in the `debug` component.

- **`registry/lib/typed-emitter.ts`**: New class using a generic `EventMap` constraint; `emit` is `protected` to keep the event surface encapsulated, and `on` returns an unsubscribe function. One subtle limitation: `off(event, listener)` silently does nothing for listeners registered via `once`, because `tiny-emitter` wraps those internally.
- **Registry & docs**: New `public/r/typed-emitter.json`, `registry.json` entry, and `content/components/typed-emitter.mdx` are all consistent with each other and with the source.
- **Debug fix**: `@types/lodash.debounce` correctly added to both `public/r/debug.json` and the registry entries.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new TypedEmitter implementation is correct for the common on/off/emit path, with one undisclosed edge case around cancelling once listeners.

The on/emit/off flow works as expected and the debug type-dependency fix is straightforward. The only notable issue is that off(event, listener) silently fails when the listener was originally registered via once, because tiny-emitter stores an internal wrapper rather than the original function. This won't cause runtime failures but could confuse callers expecting symmetric cancellation.

registry/lib/typed-emitter.ts and content/components/typed-emitter.mdx — the off behaviour for once-registered listeners could use a clarifying note.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| registry/lib/typed-emitter.ts | New TypedEmitter class wrapping tiny-emitter with a typed event map; implementation is clean but `off` silently fails when passed a listener originally registered via `once` due to tiny-emitter's internal wrapper |
| content/components/typed-emitter.mdx | New docs page for TypedEmitter; accurate API table but the `off` entry doesn't note that listener-specific removal doesn't work for `once`-registered listeners |
| public/r/typed-emitter.json | New registry item JSON for typed-emitter; content matches the source file; missing trailing newline |
| public/r/debug.json | Adds `@types/lodash.debounce` to debug component dependencies — fixes a missing type declaration |
| registry.json | Registers the new typed-emitter lib entry and adds `@types/lodash.debounce` to the debug entry |
| public/r/registry.json | Mirror of registry.json changes for the public registry endpoint |
| content/components/meta.json | Adds 'typed-emitter' to the component listing, correctly placed in alphabetical order |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
registry/lib/typed-emitter.ts:26-34
**`off` cannot remove `once`-registered listeners by reference**

`tiny-emitter` internally wraps the listener passed to `once` in an anonymous function (to auto-remove after first fire). When a caller holds a reference to the original listener and calls `off(event, listener)`, the lookup finds no match — the wrapper reference is what was stored, not the original. Calling `off('event')` (no listener arg) still works to cancel all listeners, but the per-listener form silently fails for `once` listeners. The docs say "Unsubscribe a specific listener" without caveat, which may mislead users who try to cancel a pending `once` subscription. Consider noting this limitation in the docs or returning a cancellable handle from `once`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix type errir"](https://github.com/joyco-studio/hub/commit/ed4c96d3a1c8d96a4be647eb5eb7e0bdd4656d7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31059797)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->