### PR TITLE
Add blend modes math reference guide

### DIFF
--- a/content/logs/14-blend-modes-math.mdx
+++ b/content/logs/14-blend-modes-math.mdx
@@ -1,0 +1,98 @@
+---
+title: 14 - Blend Modes Math
+description: Quick glossary of the math behind common layer blend modes, for shader work.
+author: 'joyboy'
+---
+
+## Setup
+
+Pick two pixels. `a` is the base (what's already there), `b` is the blend (the layer on top). Both channels are floats in `[0, 1]`, **in linear space** (sRGB math is already wrong, see [10 - Color Spaces](/logs/10-color-spaces-srgb-linear)).
+
+A blend mode is just a per-channel function `f(a, b) → result`. The names are conventions, the formulas are the truth.
+
+## The cheatsheet
+
+### Multiply — `a * b`
+
+Anything in `[0, 1]` multiplied stays in `[0, 1]` and only goes down. White leaves `a` unchanged, black crushes to zero. Shadows, tinting, baking AO onto base color.
+
+### Screen — `1 - (1 - a) * (1 - b)`
+
+Multiply in inverse-space: flip, multiply, flip back. Black is the no-op, white blows out. Highlights, bloom, additive light that doesn't clip as fast as `a + b`.
+
+### Add / Linear Dodge — `a + b`
+
+The most literal "add light." Unbounded, clips above `1`. Emissives, particles, glow.
+
+### Subtract — `a - b`
+
+Strip light. Clamp to `0`.
+
+### Difference — `|a - b|`
+
+Equal pixels go black, opposites go white. Debug visualizer, XOR-ish tricks.
+
+### Darken / Lighten — `min(a, b)` / `max(a, b)`
+
+Channel-wise min/max. Cheap clamp between two passes.
+
+### Overlay — `a < 0.5 ? 2*a*b : 1 - 2*(1 - a)*(1 - b)`
+
+Multiply on the dark half of `a`, screen on the bright half. `a = 0.5` is the no-op. **Hard Light** is the same formula with `a` and `b` swapped — the blend picks the branch instead of the base.
+
+### Soft Light (W3C variant)
+
+```
+if (b <= 0.5)  a - (1 - 2*b) * a * (1 - a)
+else           a + (2*b - 1) * (g(a) - a)
+
+g(a) = a <= 0.25 ? ((16*a - 12)*a + 4)*a : sqrt(a)
+```
+
+Same intent as overlay, gentler curve, no clipping. There is no single "soft light" — Photoshop, W3C, and Pegtop all differ. Pick one and document it.
+
+### Color Dodge / Color Burn — `a / (1 - b)` / `1 - (1 - a) / b`
+
+Division-based brighten/darken. Aggressive: blows up near the singularity. Always clamp.
+
+### Linear Burn / Linear Light — `a + b - 1` / `a + 2*b - 1`
+
+Linear versions of burn / dodge-burn. Clamp to `[0, 1]`.
+
+### Exclusion — `a + b - 2*a*b`
+
+Smoother difference (no kink at `a = b`). Mid-grey on anything yields mid-grey.
+
+## Patterns
+
+- **Multiply ↔ Screen** are duals: `screen(a, b) = 1 - multiply(1 - a, 1 - b)`. Anything you darken in straight space you can brighten by flipping, multiplying, flipping back.
+- **Overlay ↔ Hard Light** are the same formula with arguments swapped.
+- **Difference ↔ Exclusion** are the same idea, exclusion is the differentiable version.
+- **Add / Subtract** ignore the `[0, 1]` contract. Feature in HDR, bug in 8-bit.
+
+## Opacity
+
+A blend mode produces a candidate `c = f(a, b)`. Top-layer opacity `α` is a final lerp against the base:
+
+```
+result = mix(a, c, α)  // a*(1 - α) + c*α
+```
+
+Not `mix(a, b, α)`. The formula runs at full strength first, then opacity dials it back. Easy to get wrong.
+
+## In a shader
+
+```glsl
+vec3 multiply(vec3 a, vec3 b) { return a * b; }
+vec3 screen(vec3 a, vec3 b)   { return 1.0 - (1.0 - a) * (1.0 - b); }
+vec3 overlay(vec3 a, vec3 b) {
+  return mix(2.0 * a * b,
+             1.0 - 2.0 * (1.0 - a) * (1.0 - b),
+             step(0.5, a));
+}
+vec3 blendWithAlpha(vec3 base, vec3 candidate, float alpha) {
+  return mix(base, candidate, alpha);
+}
+```
+
+That's the whole API. Every Photoshop layer blend is one of these (or a combination) running per channel, in linear space, with an opacity lerp on top.

--- a/content/logs/14-blend-modes-math.mdx
+++ b/content/logs/14-blend-modes-math.mdx
@@ -1,7 +1,7 @@
 ---
 title: 14 - Blend Modes Math
 description: The math behind layer blend modes (multiply, screen, overlay, dodge, burn) — what each formula actually does and how to write it in a shader.
-author: 'joyboy'
+author: 'JOYBOY-0'
 ---
 
 A blend mode is a function. Given two pixels, `a` (the base, what's already there) and `b` (the blend, the layer on top), it returns a third one. That's it. "Multiply", "Screen", "Overlay" are just names for specific tiny formulas, run **per channel**, that the industry agreed on.

--- a/content/logs/14-blend-modes-math.mdx
+++ b/content/logs/14-blend-modes-math.mdx
@@ -39,8 +39,8 @@ Not `mix(a, b, alpha)`. The blend runs at full strength first, then opacity dial
 | **Exclusion** | `a + b - 2ab` | Smoother difference (no kink at `a = b`). |
 | **Darken** | `min(a, b)` | Channel-wise minimum. |
 | **Lighten** | `max(a, b)` | Channel-wise maximum. |
-| **Overlay** | `a < 0.5 ? 2ab : 1 - 2(1-a)(1-b)` | Multiply the dark half of `a`, screen the bright half. `a = 0.5` is the no-op. |
-| **Hard Light** | Overlay with `a` and `b` swapped | The blend, not the base, picks the branch. |
+| **Overlay** | `a < 0.5 ? 2ab : 1 - 2(1-a)(1-b)` | Multiply the dark half of `a`, screen the bright half. A 50% grey blend (`b = 0.5`) is the no-op. |
+| **Hard Light** | Overlay with `a` and `b` swapped | The blend, not the base, picks the branch. `b = 0.5` is still the no-op. |
 | **Color Dodge** | `a / (1 - b)` | Aggressive brighten. Always clamp. |
 | **Color Burn** | `1 - (1 - a) / b` | Aggressive darken. Always clamp. |
 | **Linear Burn** | `a + b - 1` | Linear darken. |
@@ -68,7 +68,7 @@ Anything you can do darkening in straight space, you can do brightening by flipp
 
 ### Overlay is multiply-then-screen, gated by the base
 
-For each pixel, overlay asks "is `a` in the dark half or the bright half?" and runs multiply or screen accordingly. Mid-grey on the base does nothing. That's what makes overlay good for contrast: shadows get darker, highlights get brighter, midtones stay put.
+For each pixel, overlay asks "is `a` in the dark half or the bright half?" and runs multiply or screen accordingly. A 50% grey **blend** (`b = 0.5`) is the no-op: both branches collapse to `a`. That's why blending an image with itself in overlay mode boosts contrast: shadows get darker, highlights get brighter, and midtones (around `0.5`) barely move.
 
 ### Hard Light is overlay with swapped roles
 

--- a/content/logs/14-blend-modes-math.mdx
+++ b/content/logs/14-blend-modes-math.mdx
@@ -1,98 +1,127 @@
 ---
 title: 14 - Blend Modes Math
-description: Quick glossary of the math behind common layer blend modes, for shader work.
+description: The math behind layer blend modes (multiply, screen, overlay, dodge, burn) — what each formula actually does and how to write it in a shader.
 author: 'joyboy'
 ---
 
-## Setup
+A blend mode is a function. Given two pixels, `a` (the base, what's already there) and `b` (the blend, the layer on top), it returns a third one. That's it. "Multiply", "Screen", "Overlay" are just names for specific tiny formulas, run **per channel**, that the industry agreed on.
 
-Pick two pixels. `a` is the base (what's already there), `b` is the blend (the layer on top). Both channels are floats in `[0, 1]`, **in linear space** (sRGB math is already wrong, see [10 - Color Spaces](/logs/10-color-spaces-srgb-linear)).
+Once you have the formulas, every blend mode in Photoshop, Figma, or your favorite shader becomes a one-liner you can read and modify on sight.
 
-A blend mode is just a per-channel function `f(a, b) → result`. The names are conventions, the formulas are the truth.
+## The contract
 
-## The cheatsheet
+Two assumptions hold for every formula below:
 
-### Multiply — `a * b`
+- Channels are floats in `[0, 1]`. If you're in 8-bit, divide by 255 first.
+- All math happens in **linear space**. Color math in sRGB gives you the wrong answer (see [10 - Color Spaces](/logs/10-color-spaces-srgb-linear)). Decode → blend → encode.
 
-Anything in `[0, 1]` multiplied stays in `[0, 1]` and only goes down. White leaves `a` unchanged, black crushes to zero. Shadows, tinting, baking AO onto base color.
+A blend mode produces a _candidate_ color. **Opacity is applied separately**, as a final lerp toward the base:
 
-### Screen — `1 - (1 - a) * (1 - b)`
-
-Multiply in inverse-space: flip, multiply, flip back. Black is the no-op, white blows out. Highlights, bloom, additive light that doesn't clip as fast as `a + b`.
-
-### Add / Linear Dodge — `a + b`
-
-The most literal "add light." Unbounded, clips above `1`. Emissives, particles, glow.
-
-### Subtract — `a - b`
-
-Strip light. Clamp to `0`.
-
-### Difference — `|a - b|`
-
-Equal pixels go black, opposites go white. Debug visualizer, XOR-ish tricks.
-
-### Darken / Lighten — `min(a, b)` / `max(a, b)`
-
-Channel-wise min/max. Cheap clamp between two passes.
-
-### Overlay — `a < 0.5 ? 2*a*b : 1 - 2*(1 - a)*(1 - b)`
-
-Multiply on the dark half of `a`, screen on the bright half. `a = 0.5` is the no-op. **Hard Light** is the same formula with `a` and `b` swapped — the blend picks the branch instead of the base.
-
-### Soft Light (W3C variant)
-
-```
-if (b <= 0.5)  a - (1 - 2*b) * a * (1 - a)
-else           a + (2*b - 1) * (g(a) - a)
-
-g(a) = a <= 0.25 ? ((16*a - 12)*a + 4)*a : sqrt(a)
+```glsl
+vec3 c = blend(a, b);            // the formula
+vec3 result = mix(a, c, alpha);  // a * (1 - alpha) + c * alpha
 ```
 
-Same intent as overlay, gentler curve, no clipping. There is no single "soft light" — Photoshop, W3C, and Pegtop all differ. Pick one and document it.
+Not `mix(a, b, alpha)`. The blend runs at full strength first, then opacity dials it back. People get this wrong all the time.
 
-### Color Dodge / Color Burn — `a / (1 - b)` / `1 - (1 - a) / b`
+## The formulas
 
-Division-based brighten/darken. Aggressive: blows up near the singularity. Always clamp.
+| Mode | Formula | What it does |
+|---|---|---|
+| **Normal** | `b` | Replace the base. |
+| **Multiply** | `a * b` | Darken. White is the no-op, black crushes to zero. |
+| **Screen** | `1 - (1 - a)(1 - b)` | Brighten. Inverse of multiply. Black is the no-op, white blows out. |
+| **Add** (Linear Dodge) | `a + b` | Pure additive light. Unbounded; clips above 1. |
+| **Subtract** | `a - b` | Strip light. Clamp to 0. |
+| **Difference** | `\|a - b\|` | Equal pixels → black, opposites → white. |
+| **Exclusion** | `a + b - 2ab` | Smoother difference (no kink at `a = b`). |
+| **Darken** | `min(a, b)` | Channel-wise minimum. |
+| **Lighten** | `max(a, b)` | Channel-wise maximum. |
+| **Overlay** | `a < 0.5 ? 2ab : 1 - 2(1-a)(1-b)` | Multiply the dark half of `a`, screen the bright half. `a = 0.5` is the no-op. |
+| **Hard Light** | Overlay with `a` and `b` swapped | The blend, not the base, picks the branch. |
+| **Color Dodge** | `a / (1 - b)` | Aggressive brighten. Always clamp. |
+| **Color Burn** | `1 - (1 - a) / b` | Aggressive darken. Always clamp. |
+| **Linear Burn** | `a + b - 1` | Linear darken. |
+| **Linear Light** | `a + 2b - 1` | Burn for `b < 0.5`, dodge for `b > 0.5`. |
 
-### Linear Burn / Linear Light — `a + b - 1` / `a + 2*b - 1`
+That's the whole vocabulary. Everything fancier (Vivid Light, Pin Light, Hard Mix) is a piecewise composition of two of these.
 
-Linear versions of burn / dodge-burn. Clamp to `[0, 1]`.
+## Reading the math
 
-### Exclusion — `a + b - 2*a*b`
+Three relationships are worth memorizing because they mean you don't need to look most of these up.
 
-Smoother difference (no kink at `a = b`). Mid-grey on anything yields mid-grey.
+### Multiply and Screen are duals
 
-## Patterns
-
-- **Multiply ↔ Screen** are duals: `screen(a, b) = 1 - multiply(1 - a, 1 - b)`. Anything you darken in straight space you can brighten by flipping, multiplying, flipping back.
-- **Overlay ↔ Hard Light** are the same formula with arguments swapped.
-- **Difference ↔ Exclusion** are the same idea, exclusion is the differentiable version.
-- **Add / Subtract** ignore the `[0, 1]` contract. Feature in HDR, bug in 8-bit.
-
-## Opacity
-
-A blend mode produces a candidate `c = f(a, b)`. Top-layer opacity `α` is a final lerp against the base:
-
+```text
+screen(a, b) = 1 - multiply(1 - a, 1 - b)
 ```
-result = mix(a, c, α)  // a*(1 - α) + c*α
+
+Anything you can do darkening in straight space, you can do brightening by flipping inputs, multiplying, then flipping the result. Screen "feels like" multiply with the opposite polarity because it literally is.
+
+### Overlay is multiply-then-screen, gated by the base
+
+For each pixel, overlay asks "is `a` in the dark half or the bright half?" and runs multiply or screen accordingly. Mid-grey on the base does nothing. That's what makes overlay good for contrast: shadows get darker, highlights get brighter, midtones stay put.
+
+### Hard Light is overlay with swapped roles
+
+Same formula, but the **blend** picks the branch. Pouring 0.2 grey through hard light multiplies everything. Pouring 0.8 grey screens everything. Useful when you want the top layer's brightness, not the base's, to drive the effect.
+
+### Soft Light has no canonical formula
+
+There are at least three definitions in the wild (Photoshop's, the W3C's, Pegtop's). All target the same intent (overlay-ish but gentler, no clipping at extremes), all give slightly different results. The W3C version is the one most compositing specs reference:
+
+```glsl
+float softLight(float a, float b) {
+  if (b <= 0.5) {
+    return a - (1.0 - 2.0 * b) * a * (1.0 - a);
+  }
+  float g = a <= 0.25
+    ? ((16.0 * a - 12.0) * a + 4.0) * a
+    : sqrt(a);
+  return a + (2.0 * b - 1.0) * (g - a);
+}
 ```
 
-Not `mix(a, b, α)`. The formula runs at full strength first, then opacity dials it back. Easy to get wrong.
+If "soft light" matters in your pipeline, pin a specific formula and document which one. Don't assume the artist's reference matches your shader.
 
 ## In a shader
 
-```glsl
-vec3 multiply(vec3 a, vec3 b) { return a * b; }
-vec3 screen(vec3 a, vec3 b)   { return 1.0 - (1.0 - a) * (1.0 - b); }
+The whole library fits in a few lines of GLSL:
+
+```glsl showLineNumbers
+vec3 multiply(vec3 a, vec3 b)    { return a * b; }
+vec3 screen(vec3 a, vec3 b)      { return 1.0 - (1.0 - a) * (1.0 - b); }
+vec3 add(vec3 a, vec3 b)         { return a + b; }
+vec3 subtract(vec3 a, vec3 b)    { return max(a - b, 0.0); }
+vec3 difference(vec3 a, vec3 b)  { return abs(a - b); }
+vec3 exclusion(vec3 a, vec3 b)   { return a + b - 2.0 * a * b; }
+vec3 darken(vec3 a, vec3 b)      { return min(a, b); }
+vec3 lighten(vec3 a, vec3 b)     { return max(a, b); }
+
 vec3 overlay(vec3 a, vec3 b) {
   return mix(2.0 * a * b,
              1.0 - 2.0 * (1.0 - a) * (1.0 - b),
              step(0.5, a));
 }
+
+vec3 hardLight(vec3 a, vec3 b)   { return overlay(b, a); }
+vec3 colorDodge(vec3 a, vec3 b)  { return min(a / max(1.0 - b, 1e-4), 1.0); }
+vec3 colorBurn(vec3 a, vec3 b)   { return 1.0 - min((1.0 - a) / max(b, 1e-4), 1.0); }
+vec3 linearBurn(vec3 a, vec3 b)  { return max(a + b - 1.0, 0.0); }
+vec3 linearLight(vec3 a, vec3 b) { return clamp(a + 2.0 * b - 1.0, 0.0, 1.0); }
+
 vec3 blendWithAlpha(vec3 base, vec3 candidate, float alpha) {
   return mix(base, candidate, alpha);
 }
 ```
 
-That's the whole API. Every Photoshop layer blend is one of these (or a combination) running per channel, in linear space, with an opacity lerp on top.
+`step(0.5, a)` returns `0` below `0.5` and `1` above, so `mix` with it as the third argument acts as a per-channel `if`. The `max(_, 1e-4)` on the divisions guards the singularity in dodge and burn, otherwise you'll output NaNs the moment a channel of `b` hits 0 or 1.
+
+## Things that go wrong
+
+- **Forgetting to linearize.** sRGB textures need `pow(x, 2.2)` (or the proper sRGB→linear function) before multiplication. Skip this and your "multiply" will look subtly wrong, especially in the midtones.
+- **Applying alpha inside the formula.** `mix(a, b, alpha)` is _alpha compositing_, not blend-mode opacity. Run the blend at full strength first, then mix toward the base.
+- **Reducing to a single brightness value.** Every formula above is **per channel**. Don't compute one luminance and apply it to RGB; you'll lose the color identity of the blend layer.
+- **Skipping the divide guard.** Color Dodge and Color Burn divide. Without a clamp on the denominator you'll output infinities the moment a channel hits the boundary.
+
+Layer blends look mystical in a Photoshop panel. At the pixel level they're a handful of arithmetic operations, run per channel, with an opacity lerp on top.

--- a/content/logs/14-blend-modes-math.mdx
+++ b/content/logs/14-blend-modes-math.mdx
@@ -4,6 +4,8 @@ description: The math behind layer blend modes (multiply, screen, overlay, dodge
 author: 'JOYBOY-0'
 ---
 
+import { ComponentPreview } from '@/components/preview/component-preview'
+
 A blend mode is a function. Given two pixels, `a` (the base, what's already there) and `b` (the blend, the layer on top), it returns a third one. That's it. "Multiply", "Screen", "Overlay" are just names for specific tiny formulas, run **per channel**, that the industry agreed on.
 
 Once you have the formulas, every blend mode in Photoshop, Figma, or your favorite shader becomes a one-liner you can read and modify on sight.
@@ -45,6 +47,12 @@ Not `mix(a, b, alpha)`. The blend runs at full strength first, then opacity dial
 | **Linear Light** | `a + 2b - 1` | Burn for `b < 0.5`, dodge for `b > 0.5`. |
 
 That's the whole vocabulary. Everything fancier (Vivid Light, Pin Light, Hard Mix) is a piecewise composition of two of these.
+
+## See it
+
+The base layer (`a`) in every cell is the same black→white gradient, so each strip reads left-to-right as the formula evaluated from `a = 0` to `a = 1`. Swap the top layer (`b`) to see how the same formula reacts to different content.
+
+<ComponentPreview name="blend-modes-demo" height={720} />
 
 ## Reading the math
 

--- a/demos/blend-modes-demo.tsx
+++ b/demos/blend-modes-demo.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Button } from '@/components/ui/button'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 type Mode = {
   name: string
@@ -18,11 +18,7 @@ const MODES: Mode[] = [
   { name: 'lighten', css: 'lighten', formula: 'max(a, b)' },
   { name: 'color-dodge', css: 'color-dodge', formula: 'a / (1 − b)' },
   { name: 'color-burn', css: 'color-burn', formula: '1 − (1−a) / b' },
-  {
-    name: 'hard-light',
-    css: 'hard-light',
-    formula: 'overlay, branch on b',
-  },
+  { name: 'hard-light', css: 'hard-light', formula: 'overlay, branch on b' },
   { name: 'soft-light', css: 'soft-light', formula: 'gentle overlay (W3C)' },
   { name: 'difference', css: 'difference', formula: '|a − b|' },
   { name: 'exclusion', css: 'exclusion', formula: 'a + b − 2ab' },
@@ -48,6 +44,8 @@ const PRESETS: Record<PresetKey, { label: string; image: string }> = {
   },
 }
 
+const PRESET_KEYS = Object.keys(PRESETS) as PresetKey[]
+
 function BlendModesDemo() {
   const [preset, setPreset] = React.useState<PresetKey>('gradient')
 
@@ -55,31 +53,32 @@ function BlendModesDemo() {
 
   return (
     <div
-      className="flex w-full flex-col gap-6 p-6"
+      className="flex w-full flex-col gap-8 p-6 sm:p-8"
       style={{ isolation: 'isolate' }}
     >
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-muted-foreground mr-2 font-mono text-xs uppercase tracking-wider">
+      <div className="flex flex-wrap items-center gap-3">
+        <span className="text-muted-foreground font-mono text-xs uppercase tracking-wider">
           Top layer
         </span>
-        {(Object.keys(PRESETS) as PresetKey[]).map((key) => (
-          <Button
-            key={key}
-            type="button"
-            variant={preset === key ? 'default' : 'muted'}
-            size="sm"
-            onClick={() => setPreset(key)}
-          >
-            {PRESETS[key].label}
-          </Button>
-        ))}
+        <Tabs
+          value={preset}
+          onValueChange={(v) => setPreset(v as PresetKey)}
+        >
+          <TabsList>
+            {PRESET_KEYS.map((key) => (
+              <TabsTrigger key={key} value={key}>
+                {PRESETS[key].label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
       </div>
 
-      <div className="grid grid-cols-2 gap-px bg-border sm:grid-cols-3 lg:grid-cols-4 border-border border">
+      <div className="grid grid-cols-2 gap-x-5 gap-y-7 sm:grid-cols-3 lg:grid-cols-4">
         {MODES.map((mode) => (
           <figure
             key={mode.name}
-            className="bg-background flex flex-col"
+            className="flex flex-col gap-3"
             style={{ contain: 'paint' }}
           >
             <div
@@ -90,11 +89,11 @@ function BlendModesDemo() {
                 backgroundBlendMode: mode.css,
               }}
             />
-            <figcaption className="border-border flex flex-col gap-0.5 border-t px-3 py-2">
+            <figcaption className="flex flex-col gap-1">
               <span className="font-mono text-xs uppercase tracking-wider">
                 {mode.name}
               </span>
-              <span className="text-muted-foreground font-mono text-[10px]">
+              <span className="text-muted-foreground font-mono text-[10px] leading-tight">
                 {mode.formula}
               </span>
             </figcaption>
@@ -102,7 +101,7 @@ function BlendModesDemo() {
         ))}
       </div>
 
-      <p className="text-muted-foreground text-xs">
+      <p className="text-muted-foreground text-xs leading-relaxed">
         Base (<code className="font-mono">a</code>) is a horizontal black→white
         gradient — each cell reads left-to-right as the formula evaluated at{' '}
         <code className="font-mono">a = 0</code> through{' '}

--- a/demos/blend-modes-demo.tsx
+++ b/demos/blend-modes-demo.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 
 type Mode = {
   name: string
@@ -18,7 +18,11 @@ const MODES: Mode[] = [
   { name: 'lighten', css: 'lighten', formula: 'max(a, b)' },
   { name: 'color-dodge', css: 'color-dodge', formula: 'a / (1 − b)' },
   { name: 'color-burn', css: 'color-burn', formula: '1 − (1−a) / b' },
-  { name: 'hard-light', css: 'hard-light', formula: 'overlay with a, b swapped' },
+  {
+    name: 'hard-light',
+    css: 'hard-light',
+    formula: 'overlay, branch on b',
+  },
   { name: 'soft-light', css: 'soft-light', formula: 'gentle overlay (W3C)' },
   { name: 'difference', css: 'difference', formula: '|a − b|' },
   { name: 'exclusion', css: 'exclusion', formula: 'a + b − 2ab' },
@@ -26,93 +30,70 @@ const MODES: Mode[] = [
 
 type PresetKey = 'solid' | 'bars' | 'gradient'
 
-const PRESETS: Record<
-  PresetKey,
-  { label: string; render: () => React.ReactNode }
-> = {
+const BASE_GRADIENT = 'linear-gradient(90deg, #000 0%, #fff 100%)'
+
+const PRESETS: Record<PresetKey, { label: string; image: string }> = {
   solid: {
     label: 'Solid',
-    render: () => (
-      <div
-        className="absolute inset-[18%] rounded-full"
-        style={{ background: '#ff2d8a' }}
-      />
-    ),
+    image: 'linear-gradient(0deg, #ff2d8a, #ff2d8a)',
   },
   bars: {
     label: 'RGB bars',
-    render: () => (
-      <div className="absolute inset-0 grid grid-cols-3">
-        <div style={{ background: '#ff2d2d' }} />
-        <div style={{ background: '#2dd96b' }} />
-        <div style={{ background: '#2d7dff' }} />
-      </div>
-    ),
+    image:
+      'linear-gradient(180deg, #ff2d2d 0%, #ff2d2d 33.33%, #2dd96b 33.34%, #2dd96b 66.66%, #2d7dff 66.67%, #2d7dff 100%)',
   },
   gradient: {
     label: 'Gradient',
-    render: () => (
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            'linear-gradient(180deg, #00e5ff 0%, #ffe600 50%, #ff2d8a 100%)',
-        }}
-      />
-    ),
+    image: 'linear-gradient(180deg, #00e5ff 0%, #ffe600 50%, #ff2d8a 100%)',
   },
 }
 
 function BlendModesDemo() {
   const [preset, setPreset] = React.useState<PresetKey>('gradient')
 
+  const backgroundImage = `${PRESETS[preset].image}, ${BASE_GRADIENT}`
+
   return (
-    <div className="flex w-full flex-col gap-4 p-4 sm:p-6">
+    <div
+      className="flex w-full flex-col gap-6 p-6"
+      style={{ isolation: 'isolate' }}
+    >
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-muted-foreground mr-1 text-xs tracking-wider uppercase">
+        <span className="text-muted-foreground mr-2 font-mono text-xs uppercase tracking-wider">
           Top layer
         </span>
         {(Object.keys(PRESETS) as PresetKey[]).map((key) => (
-          <button
+          <Button
             key={key}
             type="button"
+            variant={preset === key ? 'default' : 'muted'}
+            size="sm"
             onClick={() => setPreset(key)}
-            className={cn(
-              'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
-              preset === key
-                ? 'border-primary bg-primary text-primary-foreground'
-                : 'border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-            )}
           >
             {PRESETS[key].label}
-          </button>
+          </Button>
         ))}
       </div>
 
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-px bg-border sm:grid-cols-3 lg:grid-cols-4 border-border border">
         {MODES.map((mode) => (
           <figure
             key={mode.name}
-            className="border-border bg-background flex flex-col overflow-hidden rounded-md border"
+            className="bg-background flex flex-col"
+            style={{ contain: 'paint' }}
           >
-            <div className="relative aspect-square">
-              {/* base layer: horizontal grayscale ramp (a = 0 → 1) */}
-              <div
-                className="absolute inset-0"
-                style={{
-                  background: 'linear-gradient(90deg, #000 0%, #fff 100%)',
-                }}
-              />
-              {/* blend layer */}
-              <div
-                className="absolute inset-0"
-                style={{ mixBlendMode: mode.css }}
-              >
-                {PRESETS[preset].render()}
-              </div>
-            </div>
+            <div
+              aria-hidden
+              className="aspect-square w-full"
+              style={{
+                backgroundImage,
+                backgroundBlendMode: mode.css,
+              }}
+            />
             <figcaption className="border-border flex flex-col gap-0.5 border-t px-3 py-2">
-              <span className="font-mono text-xs">{mode.name}</span>
+              <span className="font-mono text-xs uppercase tracking-wider">
+                {mode.name}
+              </span>
               <span className="text-muted-foreground font-mono text-[10px]">
                 {mode.formula}
               </span>
@@ -123,10 +104,10 @@ function BlendModesDemo() {
 
       <p className="text-muted-foreground text-xs">
         Base (<code className="font-mono">a</code>) is a horizontal black→white
-        gradient, so each row reads left-to-right as the formula evaluated at{' '}
+        gradient — each cell reads left-to-right as the formula evaluated at{' '}
         <code className="font-mono">a = 0</code> through{' '}
-        <code className="font-mono">a = 1</code>. Top layer is{' '}
-        <code className="font-mono">b</code>.
+        <code className="font-mono">a = 1</code>. Top layer (
+        <code className="font-mono">b</code>) is the toggle above.
       </p>
     </div>
   )

--- a/demos/blend-modes-demo.tsx
+++ b/demos/blend-modes-demo.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type Mode = {
+  name: string
+  css: React.CSSProperties['mixBlendMode']
+  formula: string
+}
+
+const MODES: Mode[] = [
+  { name: 'normal', css: 'normal', formula: 'b' },
+  { name: 'multiply', css: 'multiply', formula: 'a · b' },
+  { name: 'screen', css: 'screen', formula: '1 − (1−a)(1−b)' },
+  { name: 'overlay', css: 'overlay', formula: 'multiply / screen on a' },
+  { name: 'darken', css: 'darken', formula: 'min(a, b)' },
+  { name: 'lighten', css: 'lighten', formula: 'max(a, b)' },
+  { name: 'color-dodge', css: 'color-dodge', formula: 'a / (1 − b)' },
+  { name: 'color-burn', css: 'color-burn', formula: '1 − (1−a) / b' },
+  { name: 'hard-light', css: 'hard-light', formula: 'overlay with a, b swapped' },
+  { name: 'soft-light', css: 'soft-light', formula: 'gentle overlay (W3C)' },
+  { name: 'difference', css: 'difference', formula: '|a − b|' },
+  { name: 'exclusion', css: 'exclusion', formula: 'a + b − 2ab' },
+]
+
+type PresetKey = 'solid' | 'bars' | 'gradient'
+
+const PRESETS: Record<
+  PresetKey,
+  { label: string; render: () => React.ReactNode }
+> = {
+  solid: {
+    label: 'Solid',
+    render: () => (
+      <div
+        className="absolute inset-[18%] rounded-full"
+        style={{ background: '#ff2d8a' }}
+      />
+    ),
+  },
+  bars: {
+    label: 'RGB bars',
+    render: () => (
+      <div className="absolute inset-0 grid grid-cols-3">
+        <div style={{ background: '#ff2d2d' }} />
+        <div style={{ background: '#2dd96b' }} />
+        <div style={{ background: '#2d7dff' }} />
+      </div>
+    ),
+  },
+  gradient: {
+    label: 'Gradient',
+    render: () => (
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(180deg, #00e5ff 0%, #ffe600 50%, #ff2d8a 100%)',
+        }}
+      />
+    ),
+  },
+}
+
+function BlendModesDemo() {
+  const [preset, setPreset] = React.useState<PresetKey>('gradient')
+
+  return (
+    <div className="flex w-full flex-col gap-4 p-4 sm:p-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-muted-foreground mr-1 text-xs tracking-wider uppercase">
+          Top layer
+        </span>
+        {(Object.keys(PRESETS) as PresetKey[]).map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setPreset(key)}
+            className={cn(
+              'rounded-md border px-3 py-1.5 text-xs font-medium transition-colors',
+              preset === key
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+            )}
+          >
+            {PRESETS[key].label}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {MODES.map((mode) => (
+          <figure
+            key={mode.name}
+            className="border-border bg-background flex flex-col overflow-hidden rounded-md border"
+          >
+            <div className="relative aspect-square">
+              {/* base layer: horizontal grayscale ramp (a = 0 → 1) */}
+              <div
+                className="absolute inset-0"
+                style={{
+                  background: 'linear-gradient(90deg, #000 0%, #fff 100%)',
+                }}
+              />
+              {/* blend layer */}
+              <div
+                className="absolute inset-0"
+                style={{ mixBlendMode: mode.css }}
+              >
+                {PRESETS[preset].render()}
+              </div>
+            </div>
+            <figcaption className="border-border flex flex-col gap-0.5 border-t px-3 py-2">
+              <span className="font-mono text-xs">{mode.name}</span>
+              <span className="text-muted-foreground font-mono text-[10px]">
+                {mode.formula}
+              </span>
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+
+      <p className="text-muted-foreground text-xs">
+        Base (<code className="font-mono">a</code>) is a horizontal black→white
+        gradient, so each row reads left-to-right as the formula evaluated at{' '}
+        <code className="font-mono">a = 0</code> through{' '}
+        <code className="font-mono">a = 1</code>. Top layer is{' '}
+        <code className="font-mono">b</code>.
+      </p>
+    </div>
+  )
+}
+
+export default BlendModesDemo


### PR DESCRIPTION
## Summary
Added a comprehensive reference guide documenting the mathematical formulas behind common layer blend modes used in shader work and graphics programming.

## Changes
- New log entry: `content/logs/14-blend-modes-math.mdx`
  - Quick glossary of blend mode formulas with practical explanations
  - Coverage of 15+ blend modes including multiply, screen, overlay, soft light, color dodge/burn, and more
  - Pattern documentation showing mathematical relationships between related blend modes
  - Opacity blending explanation with common implementation mistakes
  - GLSL shader code examples for practical implementation
  - Emphasis on linear color space requirements and per-channel operation

## Notable Details
- Clarifies that blend modes are per-channel functions and names are conventions while formulas are definitive
- Highlights the multiply ↔ screen duality and other mathematical relationships
- Addresses the opacity blending mistake (applying opacity after the blend function, not before)
- Notes that soft light has multiple variants (Photoshop, W3C, Pegtop) and recommends documenting which is used
- Includes practical guidance on clamping for unbounded operations (add, color dodge/burn)

https://claude.ai/code/session_01VvwH3WmqcoMB2AKPvdbt8P

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new MDX log entry documenting the mathematical formulas behind 15 common layer blend modes, with GLSL shader examples, an opacity-blending explanation, and notes on linear color space requirements.

- All blend mode formulas are mathematically correct, and the GLSL implementations (including the branchless `step`-based overlay) are accurate.
- The Overlay section incorrectly states that `a = 0.5` is the no-op; the actual neutral color is `b = 0.5` (a 50% grey blend layer leaves the base unchanged), and this distinction matters since Hard Light — correctly identified as the swapped variant — uses `a = 0.5` as its neutral.
</details>

<h3>Confidence Score: 3/5</h3>

The file is a developer reference guide — the factual error in the Overlay section would mislead readers about which variable carries the neutral color, and the distinction is meaningful when implementing blend modes by hand.

The rest of the formulas, GLSL snippets, and prose are accurate, but the Overlay no-op claim gets the wrong variable (a vs b), which is a concrete factual mistake in a document whose primary purpose is to be a correct reference.

content/logs/14-blend-modes-math.mdx — specifically the Overlay section's neutral-color claim

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/14-blend-modes-math.mdx | New blend modes reference guide — all formulas correct except the Overlay neutral-color claim, which incorrectly attributes the no-op condition to `a = 0.5` instead of `b = 0.5`. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/logs/14-blend-modes-math.mdx:41
The "no-op" claim refers to the wrong variable. When `a = 0.5`, both branches of the Overlay formula reduce to `b`, meaning the base passes through the blend layer unchanged — that's not a no-op, it's a passthrough. The actual neutral/no-op condition for Overlay is when **`b = 0.5`**: plugging in `b = 0.5` gives `2*a*0.5 = a` (dark branch) and `1 - 2*(1-a)*0.5 = a` (bright branch), so the blend layer has zero effect on the base. This matches how Photoshop documents it — a 50% grey layer in Overlay mode leaves the composition unchanged.

```suggestion
Multiply on the dark half of `a`, screen on the bright half. `b = 0.5` is the no-op (a 50% grey blend layer leaves the base unchanged). **Hard Light** is the same formula with `a` and `b` swapped — the blend picks the branch instead of the base, so `a = 0.5` becomes its no-op.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add log 14: blend modes math glossary"](https://github.com/joyco-studio/hub/commit/a84e8d0b6b78ea9a31e225ac8c2f7a5725d1e6a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31363414)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->