### PR TITLE
feat(toolbox): add tmux setup guide

### DIFF
--- a/content/toolbox/aliases.mdx
+++ b/content/toolbox/aliases.mdx
@@ -60,6 +60,9 @@ alias mkdir="mkdir -pv"
 alias myip="curl ifconfig.me"
 alias ports="netstat -tulanp"
 
+## tmux
+alias t="tmux"
+
 ## Claude
 alias clauded="claude --dangerously-skip-permissions"
 

--- a/content/toolbox/meta.json
+++ b/content/toolbox/meta.json
@@ -6,6 +6,7 @@
     "skills",
     "cw",
     "aliases",
+    "tmux",
     "agents",
     "pr-guidelines",
     "tailwind",

--- a/content/toolbox/tmux.mdx
+++ b/content/toolbox/tmux.mdx
@@ -1,0 +1,169 @@
+---
+title: tmux
+description: A themed tmux setup with one session per project and persistence across reboots.
+maintainers: ['alejopequeno']
+docLinks:
+  [
+    {
+      label: 'tmux',
+      href: 'https://github.com/tmux/tmux',
+    },
+    {
+      label: 'TPM',
+      href: 'https://github.com/tmux-plugins/tpm',
+    },
+  ]
+---
+
+## Why tmux?
+
+One terminal, many persistent workspaces. Run a **session per project** with a window per task —
+editor, dev server, logs, git, REPLs — all in the same place. Close the terminal and reattach
+later: everything is exactly where you left it, still running.
+
+The workflow that makes it click:
+
+- **Session per project** — each project gets its own named, self-contained workspace.
+- **Window per task** — one for the dev server, one for git, one for logs, and so on.
+- **Detach, don't kill** — closing the terminal just detaches; processes keep running in the
+  background until you reattach.
+
+A concrete win: keep a long-running CLI like **Claude Code** in its own window and closing the
+terminal won't lose its context. Because detach leaves the process alive, the conversation stays
+exactly where it was — reattach later and pick up mid-thread, no `--resume` needed. (That only
+applies to detach; a full reboot still kills the server — see [Persistence across
+reboots](#persistence-across-reboots) below.)
+
+## Install
+
+```bash
+brew install tmux
+```
+
+## Keybindings
+
+Prefix is remapped to `C-a` (easier to reach than the default `C-b`).
+
+| Action            | Keys                  |
+| ----------------- | --------------------- |
+| Prefix            | `C-a`                 |
+| Reload config     | `prefix` + `r`        |
+| Split vertical    | `prefix` + `\|`       |
+| Split horizontal  | `prefix` + `-`        |
+| Navigate panes    | `prefix` + `h/j/k/l`  |
+| Last window       | `prefix` + `Tab`      |
+| Rename window     | `prefix` + `,`        |
+| Session switcher  | `prefix` + `S` (popup)|
+| Save sessions     | `prefix` + `C-s`      |
+| Restore sessions  | `prefix` + `C-r`      |
+| Install plugins   | `prefix` + `I`        |
+
+## The config
+
+```bash title="~/.tmux.conf"
+# ── Prefix ─────────────────────────────────────────────
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# ── General ────────────────────────────────────────────
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",xterm-256color:Tc,alacritty:Tc,xterm-ghostty:Tc"
+set -g mouse on
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+set -g history-limit 50000
+set -g escape-time 0
+set -g focus-events on
+setw -g mode-keys vi
+
+# ── Bindings ───────────────────────────────────────────
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+bind r source-file ~/.tmux.conf \; display-message "  reloaded"
+
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+bind Tab last-window
+bind S display-popup -E -w 60% -h 60% "tmux choose-tree -Zs"
+
+# vi-mode copy → system clipboard (macOS)
+bind -T copy-mode-vi v send-keys -X begin-selection
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# ── Status (JOYCO accent #ff8c42) ──────────────────────
+set -g status-position bottom
+set -g status-justify centre
+set -g status-style "bg=default fg=#b0b0b0"
+set -g status-interval 5
+
+set -g status-left-length 40
+set -g status-left "#[fg=#{?client_prefix,#ff8c42,#3a3a3a}]●#[fg=#6a6a6a] #S  "
+
+set -g status-right-length 60
+set -g status-right "#[fg=#6a6a6a]%H:%M #[fg=#3a3a3a]·#[fg=#ff8c42,bold] PEK "
+
+setw -g window-status-format "#[fg=#6a6a6a] #W "
+setw -g window-status-current-format "#[fg=#ff8c42,bold] #W "
+setw -g window-status-separator "#[fg=#3a3a3a]·"
+
+# ── Borders ────────────────────────────────────────────
+set -g pane-border-style "fg=#2a2a2a"
+set -g pane-active-border-style "fg=#5a5a5a"
+set -g pane-border-lines single
+
+# ── Messages & modes ───────────────────────────────────
+set -g message-style "bg=default fg=#ff8c42"
+set -g message-command-style "bg=default fg=#ff8c42"
+set -g mode-style "bg=#3a3a3a fg=#ffffff"
+
+# ── Plugins (TPM) ──────────────────────────────────────
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+set -g @resurrect-capture-pane-contents 'on'
+# space-separated list of programs to relaunch on restore
+set -g @resurrect-processes 'nvim vim claude'
+
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
+# keep this line at the very bottom
+run '~/.tmux/plugins/tpm/tpm'
+```
+
+## Persistence across reboots
+
+Detaching keeps sessions alive, but a **shutdown or reboot kills the tmux server** and every
+process in it. [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) +
+[tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) restore your layout
+automatically — sessions, windows, panes, and working directories all come back.
+
+```bash title="Install TPM"
+git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+```
+
+Then reload tmux and press `prefix` + `I` to install the plugins (already declared in the config
+above). Do one manual save with `prefix` + `C-s` so there's a snapshot to restore from.
+
+<Callout type="info">
+  Restored programs relaunch **fresh** — the layout (sessions, windows, panes, working
+  directories) comes back, but live in-memory state does not. Anything stateful — an editor
+  buffer, a running REPL, a long-lived process — needs its own resume path. Add the programs
+  worth relaunching to `@resurrect-processes`, and rely on each tool's own restore mechanism for
+  the actual state.
+
+  **Example with Claude Code:** add `claude` to `@resurrect-processes` and the pane relaunches
+  the CLI on restore, but with an empty conversation. Run `claude --resume` inside that pane to
+  pick the session back up — history is stored per directory, so when the window is sitting in
+  the project folder it lists exactly that project's conversations. tmux brings back the
+  *window*; `--resume` brings back the *context*.
+</Callout>

--- a/content/toolbox/tmux.mdx
+++ b/content/toolbox/tmux.mdx
@@ -17,21 +17,21 @@ docLinks:
 
 ## Why tmux?
 
-One terminal, many persistent workspaces. Run a **session per project** with a window per task —
-editor, dev server, logs, git, REPLs — all in the same place. Close the terminal and reattach
+One terminal, many persistent workspaces. Run a **session per project** with a window per task:
+editor, dev server, logs, git, REPLs, all in the same place. Close the terminal and reattach
 later: everything is exactly where you left it, still running.
 
 The workflow that makes it click:
 
-- **Session per project** — each project gets its own named, self-contained workspace.
-- **Window per task** — one for the dev server, one for git, one for logs, and so on.
-- **Detach, don't kill** — closing the terminal just detaches; processes keep running in the
+- **Session per project:** each project gets its own named, self-contained workspace.
+- **Window per task:** one for the dev server, one for git, one for logs, and so on.
+- **Detach, don't kill:** closing the terminal just detaches; processes keep running in the
   background until you reattach.
 
 A concrete win: keep a long-running CLI like **Claude Code** in its own window and closing the
 terminal won't lose its context. Because detach leaves the process alive, the conversation stays
-exactly where it was — reattach later and pick up mid-thread, no `--resume` needed. (That only
-applies to detach; a full reboot still kills the server — see [Persistence across
+exactly where it was; reattach later and pick up mid-thread, no `--resume` needed. (That only
+applies to detach; a full reboot still kills the server. See [Persistence across
 reboots](#persistence-across-reboots) below.)
 
 ## Install
@@ -145,7 +145,7 @@ run '~/.tmux/plugins/tpm/tpm'
 Detaching keeps sessions alive, but a **shutdown or reboot kills the tmux server** and every
 process in it. [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) +
 [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) restore your layout
-automatically — sessions, windows, panes, and working directories all come back.
+automatically: sessions, windows, panes, and working directories all come back.
 
 ```bash title="Install TPM"
 git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
@@ -155,15 +155,15 @@ Then reload tmux and press `prefix` + `I` to install the plugins (already declar
 above). Do one manual save with `prefix` + `C-s` so there's a snapshot to restore from.
 
 <Callout type="info">
-  Restored programs relaunch **fresh** — the layout (sessions, windows, panes, working
-  directories) comes back, but live in-memory state does not. Anything stateful — an editor
-  buffer, a running REPL, a long-lived process — needs its own resume path. Add the programs
+  Restored programs relaunch **fresh**: the layout (sessions, windows, panes, working
+  directories) comes back, but live in-memory state does not. Anything stateful, such as an editor
+  buffer, a running REPL, or a long-lived process, needs its own resume path. Add the programs
   worth relaunching to `@resurrect-processes`, and rely on each tool's own restore mechanism for
   the actual state.
 
   **Example with Claude Code:** add `claude` to `@resurrect-processes` and the pane relaunches
   the CLI on restore, but with an empty conversation. Run `claude --resume` inside that pane to
-  pick the session back up — history is stored per directory, so when the window is sitting in
+  pick the session back up; history is stored per directory, so when the window is sitting in
   the project folder it lists exactly that project's conversations. tmux brings back the
   *window*; `--resume` brings back the *context*.
 </Callout>


### PR DESCRIPTION
## Problem

The toolbox covered shell aliases, scripts, and other terminal tooling, but had no entry for tmux — the piece that ties a per-project terminal workflow together. New team members had no shared reference for a sane, themed tmux setup or how to keep sessions alive across terminal restarts and reboots.

## Result

Adds a `tmux` toolbox page documenting an opinionated, ready-to-copy setup:

- **Themed config** using the JOYCO accent (`#ff8c42`) in the status bar, `C-a` prefix, vi-mode, and sensible split/navigation bindings.
- **Workflow framing** — session per project, window per task, detach-don't-kill. Includes the everyday win: keeping a long-running CLI (e.g. Claude Code) alive in its own window so closing the terminal never loses context.
- **Persistence across reboots** via tmux-resurrect + tmux-continuum, with a clear note that restored programs relaunch fresh and stateful tools rely on their own resume path.
- **Install** section (`brew install tmux`) and a keybindings reference table.

Also adds the `t="tmux"` alias to the existing **Shell Aliases** page and registers the new page in `content/toolbox/meta.json`.

Verified locally: `/toolbox/tmux` renders with HTTP 200 and full content.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new `/toolbox/tmux` page with an opinionated, ready-to-copy tmux config (JOYCO-themed status bar, `C-a` prefix, vi-mode, persistence via tmux-resurrect + tmux-continuum), registers it in `meta.json`, and drops a `t="tmux"` alias into the Shell Aliases page.

- **`content/toolbox/tmux.mdx`**: New guide covering install, keybindings, the full `~/.tmux.conf` snippet, and persistence setup; includes a `Callout` explaining the Claude Code `--resume` workflow after reboot.
- **`content/toolbox/meta.json`**: `"tmux"` entry added between `"aliases"` and `"agents"`.
- **`content/toolbox/aliases.mdx`**: Single `alias t="tmux"` line added under a new `## tmux` section, consistent with the existing grouping style.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation-only and do not affect runtime behavior.

The hardcoded `PEK` label in the `status-right` line of the tmux config snippet will be copied verbatim by anyone following the guide, leaving a personal identifier in their status bar. The rest of the content is technically accurate and well-structured.

content/toolbox/tmux.mdx — specifically the `status-right` config line with the hardcoded `PEK` label.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/toolbox/tmux.mdx | New toolbox page documenting a complete tmux setup; technically accurate overall, but includes a hardcoded personal identifier ("PEK") in the status-bar config that users would copy verbatim |
| content/toolbox/meta.json | Registers the new "tmux" page in the correct position between "aliases" and "agents" |
| content/toolbox/aliases.mdx | Adds `alias t="tmux"` under a new `## tmux` section; clean and consistent with the existing alias grouping pattern |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/toolbox/tmux.mdx:111
The `PEK` label in `status-right` appears to be a personal identifier (initials or city code) that was left in from the author's own config. Any team member who copies this snippet verbatim will end up with "PEK" permanently displayed in their status bar. Consider replacing it with a comment placeholder so it's clear this is meant to be customized.

```suggestion
set -g status-right "#[fg=#6a6a6a]%H:%M #[fg=#3a3a3a]·#[fg=#ff8c42,bold] YOUR_INITIALS "  # replace with your initials
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(toolbox): add tmux setup guide"](https://github.com/joyco-studio/hub/commit/c93c1ac18c50fef0734dbdbd0bb84f6f5989584a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37112730)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->