### PR TITLE
feat(logs): phantom merge conflicts log entry + new toolbox skills

### DIFF
--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -12,7 +12,7 @@ The long answer is a story. Let me introduce you to Elvira and Homero.
 
 ## A Thursday like any other
 
-Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to wait for her PR to land. So he branches off her branch:
+Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
 
 ```bash
 main ← elvira/checkout ← homero/receipts
@@ -56,11 +56,11 @@ So don't assume the cause, diagnose it. Check whether your own commits ever touc
 git log --oneline elvira/checkout..HEAD -- checkout.ts
 ```
 
-Empty output for a conflicted file is the smoking gun: the "your side" of that conflict came from inherited history, not from work done on this branch.
+Empty output for a conflicted file is the smoking gun: the “your side” of that conflict came from inherited history, not from work done on this branch.
 
 ## Why you shouldn't resolve them by hand
 
-Hand-resolving phantom conflicts re-applies work that already landed, polluting your branch (and later, the PR diff) with someone else's changes behind a bogus merge commit. Worse, it risks resurrecting stale code: if Elvira's PR got tweaks during review (it usually does), the copy in Homero's history is older than what's on `main`, and picking "ours" brings back the pre-review version.
+Hand-resolving phantom conflicts re-applies work that already landed, polluting your branch (and later, the PR diff) with someone else's changes behind a bogus merge commit. Worse, it risks resurrecting stale code: if Elvira's PR got tweaks during review (it usually does), the copy in Homero's history is older than what's on `main`, and picking “ours” brings back the pre-review version.
 
 The conflict is a symptom. The real problem is the duplicated commits, so instead of resolving, you remove them.
 
@@ -72,7 +72,7 @@ Abort whatever operation is in progress (`git merge --abort` or `git rebase --ab
 git rebase --onto main elvira/checkout homero/receipts
 ```
 
-The arguments read as: _take every commit after `elvira/checkout`, up to the tip of `homero/receipts`, and replay them on top of `main`_.
+The arguments read as: _take every commit after `elvira/checkout`, up to the tip of `homero/receipts`, and replay them on top of `main`_. (Elvira deleted her branch, remember? If `elvira/checkout` no longer resolves, point at `origin/elvira/checkout` or grab the raw SHA, gotcha #1 below.)
 
 ```bash
 git rebase --onto <new-base> <old-base> [<branch>]
@@ -100,7 +100,7 @@ Since the rebase rewrites your branch's history, pushing afterwards needs `git p
 
 ## Or let Claude handle it
 
-We turned this whole diagnosis into a Claude Code skill: [`resolving-git-conflicts`](/toolbox/skills#resolving-git-conflicts). It's what saved the real-life Homero in this story: he asked Claude to "fix the conflicts" and, instead of blindly editing markers, the skill walked the history, detected the rewritten base, and ran the `rebase --onto` itself. Diagnose before you resolve, with a safety snapshot first and no force-push without asking.
+We turned this whole diagnosis into a Claude Code skill: [`resolving-git-conflicts`](/toolbox/skills#resolving-git-conflicts). It's what saved the real-life Homero in this story: he asked Claude to “fix the conflicts” and, instead of blindly editing markers, the skill walked the history, detected the rewritten base, and ran the `rebase --onto` itself. Diagnose before you resolve, with a safety snapshot first and no force-push without asking.
 
 ```bash
 pnpx skills add joyco-studio/skills

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -1,0 +1,146 @@
+---
+title: 14 - Phantom Merge Conflicts
+description: Why git shows conflicts in files you never touched when the history under your branch gets rewritten, and how git rebase --onto fixes them without resolving a single marker.
+author: 'justkahdri'
+---
+
+I'm sure you at least once came across a git merge conflict that showed you conflicts in a file you're pretty sure you never touched. Why is that? How do you fix it?
+
+The short answer: **the history underneath your branch got rewritten**. Someone squash-merged the branch you were stacked on, or rebased it, or amended a commit and force-pushed. The exact ceremony doesn't matter, what matters is that the commits your branch is built on now exist on the target branch under different hashes, and git has no idea they're the same work.
+
+The long answer is a story. Let me introduce you to Elvira and Homero.
+
+## A Thursday like any other
+
+Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
+
+```bash
+main ← elvira/checkout ← homero/receipts
+```
+
+A stacked branch. Totally normal, this is how parallel work on dependent features should happen.
+
+Homero builds his receipt page on top of Elvira's API. Life is good.
+
+Thursday afternoon, Elvira's PR gets approved. She **squash-merges** it into `main` (the big green button's default), deletes her branch, and goes for a coffee. She's earned it.
+
+Homero sees the merge notification and does the responsible thing:
+
+```bash
+git pull origin main
+```
+
+And git explodes. Conflicts in `checkout.ts`. Conflicts in `payment-client.ts`. Files Homero has _never opened_. He stares at the screen. "I didn't touch any of this."
+
+He didn't. And that's exactly the clue.
+
+## What git actually saw
+
+Here's the thing: **git identifies commits by hash, not by content**. Two commits that introduce the exact same changes are, as far as git's history model is concerned, complete strangers.
+
+The squash merge took all of Elvira's commits and produced **one brand-new commit** on `main` with the combined diff. Same changes, new hash, no ancestry link back to the originals. And the originals didn't disappear, they still live inside Homero's branch, because that's where he branched from.
+
+So when Homero pulls, the picture looks like this:
+
+```bash
+main:              A ── B ───────── S        (S = squash of elvira/checkout)
+                          \
+homero/receipts:           e1 ── e2 ── h1 ── h2
+                          └ Elvira's ┘└ Homero's ┘
+                             commits      commits
+```
+
+To merge, git finds the **merge base**: the most recent common ancestor of both sides. That's `B`, the point where Elvira originally forked off `main`. The squash commit `S` is not an ancestor of Homero's branch, so git can't use anything newer.
+
+From `B`'s point of view:
+
+- `main` changed `checkout.ts` and `payment-client.ts` (via `S`)
+- `homero/receipts` changed _the same files_ (via `e1` and `e2`)
+
+Git has no idea these are the same changes. It just sees two unrelated edits to the same lines and does what it's built to do: flag a conflict. The conflicts land in Elvira's files because that's where the duplicated work lives. Homero's own files merge cleanly.
+
+These are **phantom conflicts**: there's no real disagreement between the two sides, just the same work wearing two different hashes.
+
+## It's not just squash merges
+
+The squash is the everyday villain, but it's only one way to end up here. The same phantom conflicts appear whenever the base you're standing on gets its history rewritten:
+
+- **Elvira rebases her branch** on latest `main` and force-pushes it. Every one of her commits gets a new hash. Homero's branch still carries the old ones.
+- **Elvira amends a commit** after review feedback and force-pushes. Same deal, one commit, two identities.
+- **`main` itself gets force-pushed** (it happens). Everyone stacked on the old history inherits the problem.
+
+The common denominator is always the same: _your branch contains commits that the target branch now has under a different identity_. Don't assume squash is the cause, diagnose it. Check whether your own commits ever touched the conflicted files:
+
+```bash
+git log --oneline elvira/checkout..HEAD -- checkout.ts
+```
+
+Empty output for a conflicted file is the smoking gun: the "your side" of that conflict came from inherited history, not from work done on this branch.
+
+## Why you shouldn't resolve them by hand
+
+It's tempting to just open the files, pick a side, and move on. Don't. Hand-resolving phantom conflicts:
+
+- **Re-applies work that already landed.** You're merging Elvira's commits into a `main` that already contains them, polluting your branch (and later, the PR diff) with someone else's changes.
+- **Creates a bogus merge commit** that makes history harder to read and the PR harder to review.
+- **Risks reintroducing stale code.** If Elvira's PR got tweaks during review (it usually does), the version on `main` is newer than the copy in Homero's history. Picking "ours" resurrects the pre-review code.
+
+The conflict is a symptom. The actual problem is that the branch carries commits that already exist on `main` under a different identity. So instead of resolving, you remove the duplicates.
+
+## The fix: `git rebase --onto`
+
+First, abort whatever operation is in progress:
+
+```bash
+git merge --abort   # or git rebase --abort
+```
+
+Then transplant **only your own commits** onto the new `main`:
+
+```bash
+git rebase --onto main elvira/checkout homero/receipts
+```
+
+The three arguments read as: _take every commit after `elvira/checkout`, up to and including `homero/receipts`, and replay them on top of `main`_.
+
+```bash
+git rebase --onto <new-base> <old-base> <branch>
+                      │           │         │
+                      │           │         └─ what to move (your branch)
+                      │           └─ where your own work starts (exclusive)
+                      └─ where it should land
+```
+
+Elvira's commits (`e1`, `e2`) fall outside the `<old-base>..<branch>` range, so they're simply left behind. Only `h1` and `h2` get replayed, and since they never touched Elvira's files, the rebase completes with **zero conflicts**:
+
+```bash
+main:              A ── B ── S
+                             \
+homero/receipts:              h1' ── h2'
+```
+
+Homero's branch now contains exactly Homero's work, sitting on top of a `main` that already includes Elvira's. Which is what was true all along, git just needed help seeing it.
+
+A few gotchas worth knowing:
+
+1. **If the parent branch was deleted after merging** (GitHub loves doing this), you can't reference it anymore. Run `git log --oneline main..your-branch` and find the boundary where the commits stop being yours, that SHA is your `<old-base>`. Or if you know you have N commits of your own: `git rebase --onto main HEAD~N`.
+2. **If the base was force-pushed instead of squashed**, the recipe is identical, only finding the old base changes: the pre-rewrite tip lives in the remote-tracking reflog, `git rebase --onto origin/elvira/checkout 'origin/elvira/checkout@{1}' homero/receipts`.
+3. **Don't use `git merge-base main your-branch` as the old base.** It returns `B`, the original fork point _below_ the parent's commits, which would replay Elvira's work all over again, exactly what we're trying to avoid.
+
+Since the rebase rewrites your branch's history, pushing afterwards needs `git push --force-with-lease` (never bare `--force`, the lease aborts if someone else pushed in the meantime).
+
+## Or let Claude handle it
+
+We turned this whole diagnosis into a Claude Code skill: [`resolving-git-conflicts`](/toolbox/skills#resolving-git-conflicts). It's what actually saved the real-life Homero in this story, he asked Claude to "fix the conflicts", and instead of blindly editing markers, the skill walked the history, detected the rewritten base, and ran the `rebase --onto` itself.
+
+The core rule baked into it is **diagnose before you resolve**: check whether your branch's own commits ever touched the conflicted files, look for the duplicated work under its new identity, and only hand-resolve when the divergence is real. It also takes a safety snapshot first and never force-pushes without asking.
+
+```bash
+pnpx skills add joyco-studio/skills
+```
+
+## Links
+
+- [resolving-git-conflicts skill](/toolbox/skills#resolving-git-conflicts)
+- [`joyco-studio/skills` on GitHub](https://github.com/joyco-studio/skills)
+- [git rebase --onto docs](https://git-scm.com/docs/git-rebase)

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -12,7 +12,7 @@ The long answer is a story. Let me introduce you to Elvira and Homero.
 
 ## A Thursday like any other
 
-Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
+Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to wait for her PR to land. So he branches off her branch:
 
 ```bash
 main ← elvira/checkout ← homero/receipts
@@ -20,27 +20,19 @@ main ← elvira/checkout ← homero/receipts
 
 A stacked branch. Totally normal, this is how parallel work on dependent features should happen.
 
-Homero builds his receipt page on top of Elvira's API. Life is good.
-
-Thursday afternoon, Elvira's PR gets approved. She **squash-merges** it into `main` (the big green button's default), deletes her branch, and goes for a coffee. She's earned it.
-
-Homero sees the merge notification and does the responsible thing:
+Thursday afternoon, Elvira's PR gets approved. She **squash-merges** it into `main` (the big green button's default), deletes her branch, and goes for a coffee. Homero sees the merge notification and does the responsible thing:
 
 ```bash
 git pull origin main
 ```
 
-And git explodes. Conflicts in `checkout.ts`. Conflicts in `payment-client.ts`. Files Homero has _never opened_. He stares at the screen. "I didn't touch any of this."
-
-He didn't. And that's exactly the clue.
+And git explodes. Conflicts in `checkout.ts`. Conflicts in `payment-client.ts`. Files Homero has _never opened_. And that's exactly the clue.
 
 ## What git actually saw
 
-Here's the thing: **git identifies commits by hash, not by content**. Two commits that introduce the exact same changes are, as far as git's history model is concerned, complete strangers.
+**Git identifies commits by hash, not by content.** Two commits that introduce the exact same changes are, as far as git's history model is concerned, complete strangers.
 
-The squash merge took all of Elvira's commits and produced **one brand-new commit** on `main` with the combined diff. Same changes, new hash, no ancestry link back to the originals. And the originals didn't disappear, they still live inside Homero's branch, because that's where he branched from.
-
-So when Homero pulls, the picture looks like this:
+The squash merge took all of Elvira's commits and produced **one brand-new commit** on `main` with the combined diff. Same changes, new hash, no ancestry link back to the originals, which still live inside Homero's branch, because that's where he branched from:
 
 ```bash
 main:              A ── B ───────── S        (S = squash of elvira/checkout)
@@ -50,26 +42,15 @@ homero/receipts:           e1 ── e2 ── h1 ── h2
                              commits      commits
 ```
 
-To merge, git finds the **merge base**: the most recent common ancestor of both sides. That's `B`, the point where Elvira originally forked off `main`. The squash commit `S` is not an ancestor of Homero's branch, so git can't use anything newer.
+To merge, git walks back to the **merge base**, the most recent common ancestor of both sides: `B`. The squash `S` is not an ancestor of Homero's branch, so from `B`'s point of view both sides changed the same files: `main` via `S`, `homero/receipts` via `e1` and `e2`. Git can't tell these are the same changes. It just sees two unrelated edits to the same lines and flags a conflict. The conflicts land in Elvira's files because that's where the duplicated work lives.
 
-From `B`'s point of view:
-
-- `main` changed `checkout.ts` and `payment-client.ts` (via `S`)
-- `homero/receipts` changed _the same files_ (via `e1` and `e2`)
-
-Git has no idea these are the same changes. It just sees two unrelated edits to the same lines and does what it's built to do: flag a conflict. The conflicts land in Elvira's files because that's where the duplicated work lives. Homero's own files merge cleanly.
-
-These are **phantom conflicts**: there's no real disagreement between the two sides, just the same work wearing two different hashes.
+These are **phantom conflicts**: no real disagreement between the two sides, just the same work wearing two different hashes.
 
 ## It's not just squash merges
 
-The squash is the everyday villain, but it's only one way to end up here. The same phantom conflicts appear whenever the base you're standing on gets its history rewritten:
+Any rewrite of the base you're standing on produces the same effect: Elvira rebasing her branch onto latest `main` and force-pushing, an amended commit after review feedback, even a force-pushed `main`. The common denominator is always the same: _your branch contains commits that the target branch now has under a different identity_.
 
-- **Elvira rebases her branch** on latest `main` and force-pushes it. Every one of her commits gets a new hash. Homero's branch still carries the old ones.
-- **Elvira amends a commit** after review feedback and force-pushes. Same deal, one commit, two identities.
-- **`main` itself gets force-pushed** (it happens). Everyone stacked on the old history inherits the problem.
-
-The common denominator is always the same: _your branch contains commits that the target branch now has under a different identity_. Don't assume squash is the cause, diagnose it. Check whether your own commits ever touched the conflicted files:
+So don't assume the cause, diagnose it. Check whether your own commits ever touched the conflicted files:
 
 ```bash
 git log --oneline elvira/checkout..HEAD -- checkout.ts
@@ -79,39 +60,29 @@ Empty output for a conflicted file is the smoking gun: the "your side" of that c
 
 ## Why you shouldn't resolve them by hand
 
-It's tempting to just open the files, pick a side, and move on. Don't. Hand-resolving phantom conflicts:
+Hand-resolving phantom conflicts re-applies work that already landed, polluting your branch (and later, the PR diff) with someone else's changes behind a bogus merge commit. Worse, it risks resurrecting stale code: if Elvira's PR got tweaks during review (it usually does), the copy in Homero's history is older than what's on `main`, and picking "ours" brings back the pre-review version.
 
-- **Re-applies work that already landed.** You're merging Elvira's commits into a `main` that already contains them, polluting your branch (and later, the PR diff) with someone else's changes.
-- **Creates a bogus merge commit** that makes history harder to read and the PR harder to review.
-- **Risks reintroducing stale code.** If Elvira's PR got tweaks during review (it usually does), the version on `main` is newer than the copy in Homero's history. Picking "ours" resurrects the pre-review code.
-
-The conflict is a symptom. The actual problem is that the branch carries commits that already exist on `main` under a different identity. So instead of resolving, you remove the duplicates.
+The conflict is a symptom. The real problem is the duplicated commits, so instead of resolving, you remove them.
 
 ## The fix: `git rebase --onto`
 
-First, abort whatever operation is in progress:
-
-```bash
-git merge --abort   # or git rebase --abort
-```
-
-Then transplant **only your own commits** onto the new `main`:
+Abort whatever operation is in progress (`git merge --abort` or `git rebase --abort`), then transplant **only your own commits** onto the new `main`:
 
 ```bash
 git rebase --onto main elvira/checkout homero/receipts
 ```
 
-The three arguments read as: _take every commit after `elvira/checkout`, up to and including `homero/receipts`, and replay them on top of `main`_.
+The arguments read as: _take every commit after `elvira/checkout`, up to the tip of `homero/receipts`, and replay them on top of `main`_.
 
 ```bash
-git rebase --onto <new-base> <old-base> <branch>
+git rebase --onto <new-base> <old-base> [<branch>]
                       │           │         │
-                      │           │         └─ what to move (your branch)
+                      │           │         └─ what to move (defaults to the branch you're on)
                       │           └─ where your own work starts (exclusive)
                       └─ where it should land
 ```
 
-Elvira's commits (`e1`, `e2`) fall outside the `<old-base>..<branch>` range, so they're simply left behind. Only `h1` and `h2` get replayed, and since they never touched Elvira's files, the rebase completes with **zero conflicts**:
+Elvira's commits fall outside the `<old-base>..<branch>` range, so they're simply left behind. Only `h1` and `h2` get replayed, and since they never touched Elvira's files, the rebase completes with **zero conflicts**:
 
 ```bash
 main:              A ── B ── S
@@ -119,21 +90,17 @@ main:              A ── B ── S
 homero/receipts:                  h1' ── h2'
 ```
 
-Homero's branch now contains exactly Homero's work, sitting on top of a `main` that already includes Elvira's. Which is what was true all along, git just needed help seeing it.
-
 A few gotchas worth knowing:
 
-1. **If the parent branch was deleted after merging** (GitHub loves doing this), you can't reference it anymore. Run `git log --oneline main..your-branch` and find the boundary where the commits stop being yours, that SHA is your `<old-base>`. Or if you know you have N commits of your own: `git rebase --onto main HEAD~N`.
-2. **If the base was force-pushed instead of squashed**, the recipe is identical, only finding the old base changes: the pre-rewrite tip lives in the remote-tracking reflog, `git rebase --onto origin/elvira/checkout 'origin/elvira/checkout@{1}' homero/receipts`.
-3. **Don't use `git merge-base main your-branch` as the old base.** It returns `B`, the original fork point _below_ the parent's commits, which would replay Elvira's work all over again, exactly what we're trying to avoid.
+1. **If the parent branch was deleted after merging** (GitHub loves doing this), find the old base in `git log --oneline main..your-branch`: the boundary where the commits stop being yours. Or if you know you have N commits of your own: `git rebase --onto main HEAD~N`.
+2. **If the base was force-pushed instead of squashed**, the pre-rewrite tip lives in the remote-tracking reflog: `git rebase --onto origin/elvira/checkout 'origin/elvira/checkout@{1}'`.
+3. **Don't use `git merge-base main your-branch` as the old base.** It returns `B`, below the parent's commits, and would replay Elvira's work all over again.
 
 Since the rebase rewrites your branch's history, pushing afterwards needs `git push --force-with-lease` (never bare `--force`, the lease aborts if someone else pushed in the meantime).
 
 ## Or let Claude handle it
 
-We turned this whole diagnosis into a Claude Code skill: [`resolving-git-conflicts`](/toolbox/skills#resolving-git-conflicts). It's what actually saved the real-life Homero in this story, he asked Claude to "fix the conflicts", and instead of blindly editing markers, the skill walked the history, detected the rewritten base, and ran the `rebase --onto` itself.
-
-The core rule baked into it is **diagnose before you resolve**: check whether your branch's own commits ever touched the conflicted files, look for the duplicated work under its new identity, and only hand-resolve when the divergence is real. It also takes a safety snapshot first and never force-pushes without asking.
+We turned this whole diagnosis into a Claude Code skill: [`resolving-git-conflicts`](/toolbox/skills#resolving-git-conflicts). It's what saved the real-life Homero in this story: he asked Claude to "fix the conflicts" and, instead of blindly editing markers, the skill walked the history, detected the rewritten base, and ran the `rebase --onto` itself. Diagnose before you resolve, with a safety snapshot first and no force-push without asking.
 
 ```bash
 pnpx skills add joyco-studio/skills

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -115,8 +115,8 @@ Elvira's commits (`e1`, `e2`) fall outside the `<old-base>..<branch>` range, so 
 
 ```bash
 main:              A ── B ── S
-                             \
-homero/receipts:              h1' ── h2'
+                                 \
+homero/receipts:                  h1' ── h2'
 ```
 
 Homero's branch now contains exactly Homero's work, sitting on top of a `main` that already includes Elvira's. Which is what was true all along, git just needed help seeing it.

--- a/content/toolbox/skills.mdx
+++ b/content/toolbox/skills.mdx
@@ -64,3 +64,47 @@ Analyze a Chrome DevTools Performance trace JSON file for performance anomalies.
 ```
 
 Runs 13 detection categories in parallel: Long Tasks, Layout Thrashing, Forced Reflows, rAF Ticker Loops, Style Recalc Storms, Paint Storms, GC Pressure, CLS, INP, Network Errors, Redundant Fetches, Script Eval, and Long Animation Frames, then produces a structured audit report with severity classifications and timeline hotspots.
+
+---
+
+### lab-experiment
+
+Automates the full workflow of extracting a self-contained experiment from any codebase and publishing it to the JOYCO Lab: identifies what the experiment does and which template fits (`3d` for Three.js / R3F scenes, `motion` for GSAP / Framer Motion / canvas 2D work), scaffolds it with the matching JOYCO template, ports the code and its dependencies, deploys to Vercel, and opens the registry PR.
+
+Triggers on requests like "isolate this", "publish this to the lab", or "make this an experiment". Requires the `joyco` and `vercel` CLIs plus GitHub auth.
+
+---
+
+### thrash-report-analyzer
+
+Analyze a [`bye-thrash`](https://github.com/joyco-studio/bye-thrash) layout thrashing report and turn it into actionable fixes. Usage:
+
+```bash
+/thrash-report-analyzer <path-to-report.json>
+```
+
+For every thrash entry it parses the captured stack trace, filters out library / React / bundler internals to pinpoint the user-code function responsible, locates the offending style-write → layout-read pair in your source files, and produces a structured fix-suggestion report.
+
+---
+
+### webaudio
+
+Add sound effects, UI audio, and ambient loops to a web app using [`@joycostudio/suno`](https://github.com/joyco-studio/suno). Picks the right entry point for your stack (vanilla vs React, with or without the `Mixer` for fades), writes a typed sound manifest, and wires the unlock gesture so audio actually plays after the browser's autoplay restrictions.
+
+Built around the library's `Voice → AudioSource → effect chain → masterOutput` model: every `play()` spawns an independent voice, so overlapping playback, per-voice control, and effect chains (filter, reverb, delay) come for free. Not meant for music-player UIs, recording, or streaming.
+
+---
+
+### react-ts-debugging
+
+Debug React and TypeScript bugs through a collaborative, log-driven loop instead of read-and-guess. Claude can't see the running app, so it treats every bug as a joint investigation: reproduce, state falsifiable hypotheses, place a few strategic console logs, then stop and hand off. You run the app, paste the console output back, and the evidence — not the source code — drives the next step. Fixes only land once a log has demonstrated the root cause, and every debug log gets cleaned up afterwards.
+
+Triggers on anything from "why is my component re-rendering" to "this works sometimes but not always", even when you just paste a broken component.
+
+---
+
+### resolving-git-conflicts
+
+Diagnose and resolve git conflicts of any kind — merge, rebase, cherry-pick, stash, revert. The core rule is **diagnose before you resolve**: many conflicts (especially in stacked-branch workflows) are phantom artifacts of squash merges or rewritten upstream history, where the correct fix is a different git strategy like `git rebase --onto`, not hand-editing conflict markers.
+
+Works through ordered phases: a safety snapshot (backup branch from `ORIG_HEAD`), identifying the in-progress operation from `.git` state files, mapping the history topology to find the real cause, and only then resolving — with correct handling of the `ours`/`theirs` inversion under rebase. Never force-pushes without asking first.


### PR DESCRIPTION
## Summary

Adds **log 14 — Phantom Merge Conflicts** and documents the new skills on the toolbox page.

### `content/logs/14-phantom-merge-conflicts.mdx`

A didactic entry on why git shows conflicts in files you never touched. Told as a short story (Elvira squash-merges `elvira/checkout`; Homero, stacked on it with `homero/receipts`, pulls `main` and gets phantom conflicts):

- Why it happens: git identifies commits by hash, not content — rewritten base history (squash merge, rebase, amend + force-push) leaves the same work under two identities, and the stale merge base makes git flag it as conflicting.
- Why hand-resolving is the wrong fix (re-applies landed work, bogus merge commits, resurrects pre-review code).
- The right fix: `git rebase --onto <new-base> <old-base> <branch>`, with an annotated breakdown of the three arguments and the common gotchas (deleted parent branch, force-pushed base, the `merge-base` trap).
- Links to the [`resolving-git-conflicts`](https://github.com/joyco-studio/skills) skill that automates the diagnosis.

### `content/toolbox/skills.mdx`

Documents five new skills: `lab-experiment`, `thrash-report-analyzer`, `webaudio`, `react-ts-debugging`, and `resolving-git-conflicts` (which the log entry links to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds log entry #14 on phantom merge conflicts and documents five new Claude Code skills on the toolbox page. The log is well-written and technically sound, covering the squash-merge root cause, ASCII diagrams, the `git rebase --onto` fix, and three practical gotchas.

- **`content/logs/14-phantom-merge-conflicts.mdx`**: New educational post explaining phantom conflicts caused by rewritten upstream history, with the `rebase --onto` recipe and gotcha callouts.
- **`content/toolbox/skills.mdx`**: Five new skill entries (`lab-experiment`, `thrash-report-analyzer`, `webaudio`, `react-ts-debugging`, `resolving-git-conflicts`) appended in the established section format.
</details>

<h3>Confidence Score: 4/5</h3>

Pure content/documentation changes with no code execution path — safe to merge as-is, with minor prose polish recommended.

Both files are MDX content with no logic or runtime code. The only issues are two straight-quote typography violations (per the AGENTS.md style guide) and a minor clarity gap in the primary recipe example that references a branch the story has already described as deleted — something a reader following along in their terminal would hit before reaching the gotcha section.

content/logs/14-phantom-merge-conflicts.mdx — straight-quote fixes and a clarifying note on the recipe command; content/toolbox/skills.mdx is clean.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/14-phantom-merge-conflicts.mdx | New log entry on phantom merge conflicts — well-structured and technically accurate; two straight-quote typography violations per AGENTS.md, and the primary recipe example references a branch the story has already established as deleted. |
| content/toolbox/skills.mdx | Adds five new skill entries (lab-experiment, thrash-report-analyzer, webaudio, react-ts-debugging, resolving-git-conflicts) in the established format; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/logs/14-phantom-merge-conflicts.mdx:33
**Straight quotes in prose**

The AGENTS.md typography rule requires curly (smart) quotes instead of straight ASCII `"`. Line 33 uses `"I didn't touch any of this."` and line 134 uses `"fix the conflicts"` — both should use `"` / `"` curly-quote pairs.

### Issue 2 of 2
content/logs/14-phantom-merge-conflicts.mdx:91-93
**Primary recipe references already-deleted branch**

The story establishes that Elvira deletes her branch right after squash-merging. A reader in Homero's exact position would never have `elvira/checkout` as a local branch (he only branched off it remotely), so running `git rebase --onto main elvira/checkout homero/receipts` would fail with `fatal: ambiguous argument 'elvira/checkout'`. Gotcha #1 covers the workaround, but it appears after the recipe; a brief inline note (e.g. "assuming the branch still exists locally — see gotcha #1 otherwise") would prevent confusion for readers who try to follow along literally.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(logs): add phantom merge conflicts ..."](https://github.com/joyco-studio/hub/commit/762451086e216e06c3e5bf67db2c0d7ca6024edb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37298637)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))

<!-- /greptile_comment -->