### PR TITLE
Add "Derive, Don't Mutate" pattern documentation

### DIFF
--- a/content/logs/15-derive-dont-mutate.mdx
+++ b/content/logs/15-derive-dont-mutate.mdx
@@ -1,0 +1,88 @@
+---
+title: 15 - Derive, Don't Mutate
+description: When one value has many writers, last-write-wins quietly corrupts your output. Give each source its own slot and resolve them at one point instead.
+author: 'matiasperz'
+---
+
+Sooner or later you hit a value that more than one part of your app wants to control. A loading overlay, a debug flag, an audio duck, the strength of a postprocessing pass. Each system has a legitimate opinion about it, and each one reaches for the same field and sets it.
+
+That's where the fight starts.
+
+## The multiple writers problem
+
+The setup is innocent. You have one mutable field and a handful of places that write to it:
+
+```ts showLineNumbers
+pass.amount = 1   // inspector turns the blur up
+pass.amount = 0   // loader finishes, turns it off
+pass.amount = 0.5 // a transition fades it
+```
+
+Each line is correct on its own. The bug is that they share one slot, so the value you actually see is whoever wrote **last**. Now your output depends on call order, on timing, on which effect happened to fire this frame. Toggle the inspector while the loader is running and the blur sticks — or doesn't — and you can't tell why, because the answer isn't in any single place. It's smeared across every call site that touches the field.
+
+This is last-write-wins, and it's the default behavior of a plain variable. No one designed it. It's just what you get when N writers point at one mutable thing.
+
+## Derive, don't mutate
+
+The fix is to stop letting sources *command* the value and let them *declare intent* instead. Nobody writes the output. Each source writes its own keyed slot, and the output is **resolved** from all the slots at one point, through logic you own.
+
+```ts showLineNumbers
+/**
+ * A value owned by N independent sources instead of one mutable field. Each
+ * source writes its own keyed slot, so writers can't clobber each other, and
+ * `value` resolves them through `combine` at one point — no last-write-wins, no
+ * ordering bugs. Resolution is pull (on read), so callers never care who wrote
+ * last.
+ *
+ *   const blur = new Derived(0, maxOf)
+ *   blur.set('inspect', 1)   // game state owns this slot
+ *   blur.set('loader', 0)    // the loader owns this one
+ *   pass.amount = blur.value // resolved max, here and only here
+ */
+export class Derived<T> {
+  private slots = new Map<string, T>()
+  constructor(
+    private readonly fallback: T,
+    private readonly combine: (slots: T[], fallback: T) => T
+  ) {}
+  set(key: string, value: T): void {
+    this.slots.set(key, value)
+  }
+  clear(key: string): void {
+    this.slots.delete(key)
+  }
+  get value(): T {
+    return this.combine([...this.slots.values()], this.fallback)
+  }
+}
+
+/** Combinator: anyone can raise it; the value is the max over all sources. */
+export const maxOf = (vals: number[], fallback: number) => Math.max(fallback, ...vals)
+```
+
+That's the whole thing. About twenty lines, and it removes an entire category of bug.
+
+## Why it works
+
+Three properties do all the work.
+
+**Owned slots.** A source can only ever touch its own key. The worst a buggy system can do is declare a wrong intent *for itself* — it can't corrupt the output and it can't stomp another source. There's no shared mutable field left to fight over.
+
+**One resolution point.** The conflict logic isn't scattered anymore. It lives in `combine`, in one place you can read, test, and reason about in isolation. "What happens when the inspector and the loader disagree?" has an actual answer now, and it's a function.
+
+**Pull, not push.** `value` resolves on read, so the slots are just *current desires* with no temporal coupling. Order of mutation stops mattering — there's no "last write," only "what does everyone currently want," evaluated fresh every time you read. Set things in any order across any number of frames; the output is always the same function of the same state.
+
+## The combinator is the semantics
+
+`Derived` doesn't decide how conflicts resolve — `combine` does. That's deliberate. The same container expresses very different policies depending on what you pass:
+
+- `maxOf` — anyone can raise it. Good for "loudest wins" / "most blur wins."
+- a `min` — anyone can dim it.
+- a product — independent modulators that compose: `quality * fade * userSetting`.
+- a priority pick over `{ value, priority }` — an override stack, where debug or a cutscene wins over everything else.
+
+Pick the combinator that matches the rule you actually want, and the rule becomes explicit instead of emergent.
+
+## When not to reach for it
+
+If your writers are really mutually-exclusive *modes* — editing vs preview vs cutscene — that's not a fight, it's a state machine. Map each mode to a full config and model it as such. `Derived` is for when multiple independent sources each hold a genuine, simultaneous stake in one value. That's the case it's built for, and inside that case it quietly makes the state fight impossible.


### PR DESCRIPTION
Adds a new guide documenting the `Derived` pattern for managing values with multiple independent writers, preventing last-write-wins bugs in shared mutable state.

## Summary

This guide introduces a practical pattern for handling scenarios where multiple systems need to influence a single value (loading overlays, debug flags, audio ducks, etc.). Instead of allowing direct mutation of a shared field, the pattern uses keyed slots that are resolved through a combinator function at read time.

## Key Changes

- **New content page**: `content/logs/15-derive-dont-mutate.mdx`
  - Explains the multiple writers problem and why last-write-wins is problematic
  - Provides a complete `Derived<T>` class implementation (~20 lines)
  - Documents three core properties: owned slots, one resolution point, and pull-based evaluation
  - Shows how combinators (`maxOf`, `min`, product, priority) express different conflict resolution semantics
  - Clarifies when to use this pattern vs. state machines

## Implementation Details

The guide includes a generic `Derived` class that:
- Maintains a `Map` of keyed slots, one per source
- Resolves the final value through a `combine` function passed at construction
- Supports `set()`, `clear()`, and lazy `value` getter
- Eliminates temporal coupling by evaluating on read rather than write

The pattern is demonstrated with practical examples and explains why it removes an entire category of ordering and timing bugs from multi-writer scenarios.

https://claude.ai/code/session_01PWyiLud4HeaXAhMwvuDHiy

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new engineering log (`15-derive-dont-mutate.mdx`) documenting the `Derived<T>` pattern for managing values that have multiple independent writers, along with the `maxOf` combinator as a concrete example.

- Introduces a ~20-line `Derived<T>` class using a keyed `Map` of slots and a `combine` function resolved at read time, replacing last-write-wins mutable state.
- Explains three core properties (owned slots, single resolution point, pull-based evaluation) and shows how different combinators express different conflict-resolution semantics.
- The guide follows the same frontmatter structure and writing style as existing logs; only one minor semantic gap around the `fallback` parameter's dual role was found.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only concern is a documentation gap in the example combinator, not broken behaviour.

The change is a single new content file with a well-structured guide and correct TypeScript. The only thing worth fixing before the guide ships is clarifying that `fallback` is passed to `combine` on every call — not just when slots are empty — which makes it a floor in `maxOf`, potentially surprising readers who implement their own combinators.

content/logs/15-derive-dont-mutate.mdx — the `maxOf` combinator comment and surrounding prose could better explain the `fallback` floor behaviour.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/15-derive-dont-mutate.mdx | New guide documenting the Derived pattern; structure and frontmatter match existing logs; the `fallback` semantics in combinators are subtly underspecified (acts as floor in maxOf, not just a "value when empty"). |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/logs/15-derive-dont-mutate.mdx:59-60
The `fallback` plays a dual role that the guide doesn't explain: it is both the value returned when no slots are set *and* a participant in every `combine` call. In `maxOf`, this makes the fallback act as a permanent **floor** — if a slot sets a value *lower* than the fallback, the fallback wins, not the slot. For example, `new Derived(0.2, maxOf)` with `blur.set('inspector', 0.1)` would return `0.2` (the fallback), silently overriding the slot. Readers writing their own combinators may not realise `slots` can be empty, or that the fallback is always in play. Adding a one-liner note would prevent that surprise.

```suggestion
/**
 * Combinator: anyone can raise it; the value is the max over all sources.
 * Note: `fallback` is always passed to `combine`, even when slots are set —
 * here it acts as a floor. When writing custom combinators, handle `vals`
 * being empty (no sources) as well as the fallback's role in your logic.
 */
export const maxOf = (vals: number[], fallback: number) => Math.max(fallback, ...vals)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add log 15: Derive, Don&#39;t Mutate"](https://github.com/joyco-studio/hub/commit/28f09a99c3d9953c4715556b0f7face26e93def4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37922310)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->