### PR TITLE
Remove em dashes from log 15

### DIFF
--- a/content/logs/15-derive-dont-mutate.mdx
+++ b/content/logs/15-derive-dont-mutate.mdx
@@ -18,7 +18,7 @@ pass.amount = 0   // loader finishes, turns it off
 pass.amount = 0.5 // a transition fades it
 ```
 
-Each line is correct on its own. The bug is that they share one slot, so the value you actually see is whoever wrote **last**. Now your output depends on call order, on timing, on which effect happened to fire this frame. Toggle the inspector while the loader is running and the blur sticks — or doesn't — and you can't tell why, because the answer isn't in any single place. It's smeared across every call site that touches the field.
+Each line is correct on its own. The bug is that they share one slot, so the value you actually see is whoever wrote **last**. Now your output depends on call order, on timing, on which effect happened to fire this frame. Toggle the inspector while the loader is running and the blur sticks, or doesn't, and you can't tell why, because the answer isn't in any single place. It's smeared across every call site that touches the field.
 
 This is last-write-wins, and it's the default behavior of a plain variable. No one designed it. It's just what you get when N writers point at one mutable thing.
 
@@ -30,7 +30,7 @@ The fix is to stop letting sources *command* the value and let them *declare int
 /**
  * A value owned by N independent sources instead of one mutable field. Each
  * source writes its own keyed slot, so writers can't clobber each other, and
- * `value` resolves them through `combine` at one point — no last-write-wins, no
+ * `value` resolves them through `combine` at one point, with no last-write-wins, no
  * ordering bugs. Resolution is pull (on read), so callers never care who wrote
  * last.
  *
@@ -66,23 +66,23 @@ That's the whole thing. About twenty lines, and it removes an entire category of
 
 Three properties do all the work.
 
-**Owned slots.** A source can only ever touch its own key. The worst a buggy system can do is declare a wrong intent *for itself* — it can't corrupt the output and it can't stomp another source. There's no shared mutable field left to fight over.
+**Owned slots.** A source can only ever touch its own key. The worst a buggy system can do is declare a wrong intent *for itself*; it can't corrupt the output and it can't stomp another source. There's no shared mutable field left to fight over.
 
 **One resolution point.** The conflict logic isn't scattered anymore. It lives in `combine`, in one place you can read, test, and reason about in isolation. "What happens when the inspector and the loader disagree?" has an actual answer now, and it's a function.
 
-**Pull, not push.** `value` resolves on read, so the slots are just *current desires* with no temporal coupling. Order of mutation stops mattering — there's no "last write," only "what does everyone currently want," evaluated fresh every time you read. Set things in any order across any number of frames; the output is always the same function of the same state.
+**Pull, not push.** `value` resolves on read, so the slots are just *current desires* with no temporal coupling. Order of mutation stops mattering: there's no "last write," only "what does everyone currently want," evaluated fresh every time you read. Set things in any order across any number of frames; the output is always the same function of the same state.
 
 ## The combinator is the semantics
 
-`Derived` doesn't decide how conflicts resolve — `combine` does. That's deliberate. The same container expresses very different policies depending on what you pass:
+`Derived` doesn't decide how conflicts resolve; `combine` does. That's deliberate. The same container expresses very different policies depending on what you pass:
 
-- `maxOf` — anyone can raise it. Good for "loudest wins" / "most blur wins."
-- a `min` — anyone can dim it.
-- a product — independent modulators that compose: `quality * fade * userSetting`.
-- a priority pick over `{ value, priority }` — an override stack, where debug or a cutscene wins over everything else.
+- `maxOf`: anyone can raise it. Good for "loudest wins" / "most blur wins."
+- a `min`: anyone can dim it.
+- a product: independent modulators that compose: `quality * fade * userSetting`.
+- a priority pick over `{ value, priority }`: an override stack, where debug or a cutscene wins over everything else.
 
 Pick the combinator that matches the rule you actually want, and the rule becomes explicit instead of emergent.
 
 ## When not to reach for it
 
-If your writers are really mutually-exclusive *modes* — editing vs preview vs cutscene — that's not a fight, it's a state machine. Map each mode to a full config and model it as such. `Derived` is for when multiple independent sources each hold a genuine, simultaneous stake in one value. That's the case it's built for, and inside that case it quietly makes the state fight impossible.
+If your writers are really mutually-exclusive *modes* (editing vs preview vs cutscene), that's not a fight, it's a state machine. Map each mode to a full config and model it as such. `Derived` is for when multiple independent sources each hold a genuine, simultaneous stake in one value. That's the case it's built for, and inside that case it quietly makes the state fight impossible.


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes editorial punctuation edits to log entry 15, replacing all em dashes with contextually appropriate alternatives (semicolons, colons, commas, and parentheses).

- All em dash replacements are grammatically correct and improve readability; the substitutions (e.g. semicolons for clause breaks, colons before elaborations, parentheses for asides) match the surrounding prose well.
- The change to the JSDoc comment replaces `— no last-write-wins` with `, with no last-write-wins`, which is a valid rewrite but shifts from a sharp em-dash aside to a slightly wordier prepositional phrase — a minor stylistic trade-off with no accuracy impact.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — only punctuation substitutions in a content file with no functional code touched.

The change is limited to replacing em dashes with equivalent punctuation across one MDX article. Every substitution is grammatically sound, no content meaning is altered, and there are no structural or code changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/15-derive-dont-mutate.mdx | Pure editorial change: replaces em dashes with semicolons, colons, commas, and parentheses throughout the article; no functional or structural changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove em dashes from log 15"](https://github.com/joyco-studio/hub/commit/dbef91ce1c3178dfaffa63e034afd10601127da3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37923420)</sub>

<!-- /greptile_comment -->