### PR TITLE
Add rich text copy functionality to page actions

### DIFF
--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -24,6 +24,54 @@ export function useCopyToClipboard(timeout = 2000) {
   return { hasCopied, copy }
 }
 
+/**
+ * Copy rendered content to the clipboard as rich text (WYSIWYG).
+ *
+ * Writes both `text/html` and a `text/plain` fallback so pasting into a
+ * rich-text editor (Google Docs, Notion, email, …) preserves formatting,
+ * while plain-text targets still receive readable text.
+ */
+export function useCopyRichTextToClipboard(timeout = 2000) {
+  const [hasCopied, setHasCopied] = React.useState(false)
+
+  React.useEffect(() => {
+    if (hasCopied) {
+      const timer = setTimeout(() => setHasCopied(false), timeout)
+      return () => clearTimeout(timer)
+    }
+  }, [hasCopied, timeout])
+
+  const copy = React.useCallback((element: HTMLElement | null) => {
+    if (!element) return
+
+    const html = element.innerHTML
+    const plain = element.innerText
+
+    const canWriteRichText =
+      typeof ClipboardItem !== 'undefined' &&
+      typeof navigator.clipboard?.write === 'function'
+
+    if (canWriteRichText) {
+      const item = new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([plain], { type: 'text/plain' }),
+      })
+      navigator.clipboard
+        .write([item])
+        .then(() => setHasCopied(true))
+        .catch(() => {
+          navigator.clipboard.writeText(plain)
+          setHasCopied(true)
+        })
+    } else {
+      navigator.clipboard.writeText(plain)
+      setHasCopied(true)
+    }
+  }, [])
+
+  return { hasCopied, copy }
+}
+
 export function CopyButton({
   value,
   className,

--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -25,11 +25,60 @@ export function useCopyToClipboard(timeout = 2000) {
 }
 
 /**
+ * Build clean rich-text HTML from a rendered content element.
+ *
+ * The on-page DOM carries things that don't belong in pasted content:
+ * interactive chrome (copy / download buttons) and syntax-highlighted code
+ * blocks whose per-line `<span data-line>` structure and `--shiki-*` colors
+ * collapse the moment a WYSIWYG target (e.g. x.com articles) strips classes
+ * and CSS. We clone, drop the chrome, and rebuild every code block as a plain
+ * `<pre><code>` with real newlines so it survives as an actual code block.
+ */
+function serializeRichTextHtml(element: HTMLElement): string {
+  const clone = element.cloneNode(true) as HTMLElement
+
+  // Drop interactive chrome (copy buttons, download buttons, …) — it should
+  // never end up in the pasted output.
+  clone.querySelectorAll('button, [data-slot="copy-button"]').forEach((el) => {
+    el.remove()
+  })
+
+  // Flatten highlighted code blocks into plain <pre><code> with real newlines.
+  clone.querySelectorAll('pre').forEach((pre) => {
+    const lines = pre.querySelectorAll('[data-line], .line')
+    const code =
+      lines.length > 0
+        ? Array.from(lines)
+            .map((line) => line.textContent ?? '')
+            .join('\n')
+        : (pre.textContent ?? '')
+
+    const newPre = document.createElement('pre')
+    const newCode = document.createElement('code')
+    newCode.textContent = code
+    newPre.appendChild(newCode)
+    pre.replaceWith(newPre)
+  })
+
+  // Resolve relative links/images to absolute so they still work once pasted
+  // off-site.
+  clone.querySelectorAll('a[href]').forEach((a) => {
+    a.setAttribute('href', (a as HTMLAnchorElement).href)
+  })
+  clone.querySelectorAll('img[src]').forEach((img) => {
+    img.setAttribute('src', (img as HTMLImageElement).src)
+  })
+
+  return clone.innerHTML
+}
+
+/**
  * Copy rendered content to the clipboard as rich text (WYSIWYG).
  *
- * Writes both `text/html` and a `text/plain` fallback so pasting into a
- * rich-text editor (Google Docs, Notion, email, …) preserves formatting,
- * while plain-text targets still receive readable text.
+ * Writes both a sanitized `text/html` payload and a `text/plain` fallback so
+ * pasting into a rich-text editor (x.com articles, Google Docs, Notion, email,
+ * …) preserves formatting and code blocks, while plain-text targets still
+ * receive readable text.
  */
 export function useCopyRichTextToClipboard(timeout = 2000) {
   const [hasCopied, setHasCopied] = React.useState(false)
@@ -44,7 +93,7 @@ export function useCopyRichTextToClipboard(timeout = 2000) {
   const copy = React.useCallback((element: HTMLElement | null) => {
     if (!element) return
 
-    const html = element.innerHTML
+    const html = serializeRichTextHtml(element)
     const plain = element.innerText
 
     const canWriteRichText =

--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -6,20 +6,31 @@ import { Check } from 'lucide-react'
 import CopyIcon from '@/components/icons/copy'
 import { cn } from '@/lib/utils'
 
-export function useCopyToClipboard(timeout = 2000) {
+/**
+ * `hasCopied` flag that auto-resets after `timeout`, shared by the copy hooks.
+ */
+function useCopiedFlag(timeout = 2000) {
   const [hasCopied, setHasCopied] = React.useState(false)
 
   React.useEffect(() => {
-    if (hasCopied) {
-      const timer = setTimeout(() => setHasCopied(false), timeout)
-      return () => clearTimeout(timer)
-    }
+    if (!hasCopied) return
+    const timer = setTimeout(() => setHasCopied(false), timeout)
+    return () => clearTimeout(timer)
   }, [hasCopied, timeout])
 
-  const copy = React.useCallback((value: string) => {
-    navigator.clipboard.writeText(value)
-    setHasCopied(true)
-  }, [])
+  return [hasCopied, setHasCopied] as const
+}
+
+export function useCopyToClipboard(timeout = 2000) {
+  const [hasCopied, setHasCopied] = useCopiedFlag(timeout)
+
+  const copy = React.useCallback(
+    (value: string) => {
+      navigator.clipboard.writeText(value)
+      setHasCopied(true)
+    },
+    [setHasCopied]
+  )
 
   return { hasCopied, copy }
 }
@@ -81,42 +92,38 @@ function serializeRichTextHtml(element: HTMLElement): string {
  * receive readable text.
  */
 export function useCopyRichTextToClipboard(timeout = 2000) {
-  const [hasCopied, setHasCopied] = React.useState(false)
+  const [hasCopied, setHasCopied] = useCopiedFlag(timeout)
 
-  React.useEffect(() => {
-    if (hasCopied) {
-      const timer = setTimeout(() => setHasCopied(false), timeout)
-      return () => clearTimeout(timer)
-    }
-  }, [hasCopied, timeout])
+  const copy = React.useCallback(
+    (element: HTMLElement | null) => {
+      if (!element) return
 
-  const copy = React.useCallback((element: HTMLElement | null) => {
-    if (!element) return
+      const html = serializeRichTextHtml(element)
+      const plain = element.innerText
 
-    const html = serializeRichTextHtml(element)
-    const plain = element.innerText
+      const canWriteRichText =
+        typeof ClipboardItem !== 'undefined' &&
+        typeof navigator.clipboard?.write === 'function'
 
-    const canWriteRichText =
-      typeof ClipboardItem !== 'undefined' &&
-      typeof navigator.clipboard?.write === 'function'
-
-    if (canWriteRichText) {
-      const item = new ClipboardItem({
-        'text/html': new Blob([html], { type: 'text/html' }),
-        'text/plain': new Blob([plain], { type: 'text/plain' }),
-      })
-      navigator.clipboard
-        .write([item])
-        .then(() => setHasCopied(true))
-        .catch(() => {
-          navigator.clipboard.writeText(plain)
-          setHasCopied(true)
+      if (canWriteRichText) {
+        const item = new ClipboardItem({
+          'text/html': new Blob([html], { type: 'text/html' }),
+          'text/plain': new Blob([plain], { type: 'text/plain' }),
         })
-    } else {
-      navigator.clipboard.writeText(plain)
-      setHasCopied(true)
-    }
-  }, [])
+        navigator.clipboard
+          .write([item])
+          .then(() => setHasCopied(true))
+          .catch(() => {
+            navigator.clipboard.writeText(plain)
+            setHasCopied(true)
+          })
+      } else {
+        navigator.clipboard.writeText(plain)
+        setHasCopied(true)
+      }
+    },
+    [setHasCopied]
+  )
 
   return { hasCopied, copy }
 }

--- a/components/layout/page-actions.tsx
+++ b/components/layout/page-actions.tsx
@@ -2,12 +2,15 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
-import { useCopyToClipboard } from '@/components/copy-button'
+import {
+  useCopyToClipboard,
+  useCopyRichTextToClipboard,
+} from '@/components/copy-button'
 import {
   ActionHintEmitter,
   useActionHint,
 } from '@/registry/components/action-hint'
-import { ChevronDown, Check, Code } from 'lucide-react'
+import { ChevronDown, Check, Code, FileText } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import {
@@ -153,7 +156,15 @@ function PageActionsDropdown({
 }) {
   const { emit } = useActionHint()
   const [open, setOpen] = useState(false)
+  const { hasCopied: hasCopiedRichText, copy: copyRichText } =
+    useCopyRichTextToClipboard()
   const getLlmPageUrl = () => `${window.location.origin}${llmUrl}`
+
+  // Copy the rendered article body as rich text (WYSIWYG)
+  const copyPageRichText = useCallback(() => {
+    const prose = document.querySelector<HTMLElement>('#nd-page .prose')
+    copyRichText(prose)
+  }, [copyRichText])
 
   useEffect(() => {
     if (!showShortcuts) return
@@ -230,6 +241,16 @@ function PageActionsDropdown({
         className="text-medium font-mono uppercase"
         align="end"
       >
+        <DropdownMenuItem
+          className="text-xs"
+          onSelect={(e) => {
+            e.preventDefault()
+            copyPageRichText()
+          }}
+        >
+          <FileText className="size-4" />
+          {hasCopiedRichText ? 'Copied!' : 'Copy Rich Text'}
+        </DropdownMenuItem>
         {componentSource && (
           <DropdownMenuItem
             className="text-xs"


### PR DESCRIPTION
## Summary
Adds support for copying rendered page content as rich text (WYSIWYG) to the clipboard, enabling users to paste formatted content into rich-text editors while maintaining fallback support for plain-text targets.

## Changes
- **New hook: `useCopyRichTextToClipboard`** in `components/copy-button.tsx`
  - Copies both `text/html` and `text/plain` MIME types to clipboard
  - Uses the modern `ClipboardItem` API when available
  - Falls back to plain text copy for unsupported browsers
  - Mirrors the timeout/feedback pattern of existing `useCopyToClipboard` hook

- **Updated page actions dropdown** in `components/layout/page-actions.tsx`
  - Imports and integrates the new rich text copy hook
  - Adds "Copy Rich Text" menu item with `FileText` icon
  - Targets the rendered article body (`.prose` element within `#nd-page`)
  - Shows "Copied!" feedback state after successful copy

## Implementation Details
- The rich text copy function gracefully degrades: attempts `ClipboardItem.write()` for HTML+plain text, falls back to `writeText()` if unavailable or on error
- Extracts both `innerHTML` (for formatting) and `innerText` (for plain text fallback) from the target element
- Maintains consistent UX with existing copy functionality through shared timeout/feedback pattern

https://claude.ai/code/session_01Nh6aD2EMSsREfFUkz1fDEc

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Review completed and submitted via submit_review tool.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after the one-line fix in the catch block; the integration in page-actions is clean.

The only defect is in copy-button.tsx: the .catch() fallback calls navigator.clipboard.writeText(plain) without chaining .then(() => setHasCopied(true)), so a double-failure surfaces false Copied! feedback.

components/copy-button.tsx — specifically the .catch() fallback inside useCopyRichTextToClipboard

<sub>Reviews (1): Last reviewed commit: ["Add WYSIWYG (rich text) copy option to p..."](https://github.com/joyco-studio/hub/commit/12f17c26721bbf84e6cb5d20aec2425b1009f244) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37976124)</sub>

<!-- /greptile_comment -->