### PR TITLE
Remove em dashes from logs and add Greptile rule to catch them

### DIFF
--- a/content/logs/11-wtf-is-layout-thrashing.mdx
+++ b/content/logs/11-wtf-is-layout-thrashing.mdx
@@ -109,5 +109,5 @@ The joyco studio team _MIGHT_ also be working on a better tool for this. Join ou
 
 ## Further reading
 
-- [What forces layout/reflow](https://gist.github.com/paulirish/5d52fb081b3570c81e3a) — Paul Irish's canonical list of properties that trigger layout
-- [Avoid large, complex layouts and layout thrashing](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing) — web.dev deep dive
+- [What forces layout/reflow](https://gist.github.com/paulirish/5d52fb081b3570c81e3a): Paul Irish's canonical list of properties that trigger layout
+- [Avoid large, complex layouts and layout thrashing](https://web.dev/articles/avoid-large-complex-layouts-and-layout-thrashing): web.dev deep dive

--- a/content/logs/12-the-render-pipeline.mdx
+++ b/content/logs/12-the-render-pipeline.mdx
@@ -1,6 +1,6 @@
 ---
 title: 12 - The Render Pipeline
-description: Deep dive into each stage of the browser rendering pipeline: what runs on main vs compositor thread and what makes each step slow.
+description: Deep dive into each stage of the browser rendering pipeline, covering what runs on main vs compositor thread and what makes each step slow.
 author: 'matiasperz'
 ---
 

--- a/content/logs/12-the-render-pipeline.mdx
+++ b/content/logs/12-the-render-pipeline.mdx
@@ -1,6 +1,6 @@
 ---
 title: 12 - The Render Pipeline
-description: Deep dive into each stage of the browser rendering pipeline — what runs on main vs compositor thread and what makes each step slow.
+description: Deep dive into each stage of the browser rendering pipeline: what runs on main vs compositor thread and what makes each step slow.
 author: 'matiasperz'
 ---
 
@@ -250,15 +250,15 @@ clip-path: polygon(...); /* complex geometry clipping */
 - **`will-change` on off-screen elements.** Promoted layers stay in GPU memory and get composited even when off-screen. If you promote 200 list items but only 10 are visible, you're paying for 200 layers.
 
 ```css
-/* The browser can cull this — content is clipped to the container */
+/* The browser can cull this: content is clipped to the container */
 .scroll-container {
   overflow: hidden; /* or auto/scroll */
   contain: paint;   /* explicitly tells the browser nothing paints outside */
 }
 
-/* The browser CANNOT cull children here — they might overflow into view */
+/* The browser CANNOT cull children here: they might overflow into view */
 .container {
-  overflow: visible; /* default — no clip boundary */
+  overflow: visible; /* default, no clip boundary */
 }
 ```
 
@@ -271,9 +271,9 @@ clip-path: polygon(...); /* complex geometry clipping */
 }
 ```
 
-This is especially effective for long pages with many sections or cards — the browser only pays the paint (and layout) cost for what's actually near the viewport.
+This is especially effective for long pages with many sections or cards: the browser only pays the paint (and layout) cost for what's actually near the viewport.
 
-**`contain: paint`** is lighter — it doesn't skip layout, but it tells the browser that nothing inside this element paints outside its bounds, which lets the compositor cull the layer when it scrolls out of view:
+**`contain: paint`** is lighter; it doesn't skip layout, but it tells the browser that nothing inside this element paints outside its bounds, which lets the compositor cull the layer when it scrolls out of view:
 
 ```css
 .widget {
@@ -355,13 +355,13 @@ Fix: use `z-index` to keep promoted elements on top, so nothing needs to be impl
 The cost scales with the **area of the element** × the **blur radius**. A small frosted chip sliding around is fine. A full-viewport `backdrop-filter: blur(20px)` panel animating its position will tank your frame rate.
 
 ```css
-/* Fine — small element, compositor handles it easily */
+/* Fine: small element, compositor handles it easily */
 .tooltip {
   backdrop-filter: blur(12px);
   transition: transform 0.2s ease;
 }
 
-/* Expensive — large area means the GPU re-samples a huge region every frame */
+/* Expensive: large area means the GPU re-samples a huge region every frame */
 .fullscreen-overlay {
   backdrop-filter: blur(20px);
   width: 100vw;

--- a/content/logs/13-working-with-reduced-motion.mdx
+++ b/content/logs/13-working-with-reduced-motion.mdx
@@ -141,7 +141,7 @@ tl.to(glow, {
 This is compositor-friendly, `xPercent`/`yPercent` compile to `translate()` inside the `transform` string. No additional pipeline stages.
 
 <Callout title="Why compositor-friendly matters" icon={<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>}>
-  Animating only `transform` and `opacity` skips Layout and Paint entirely — the compositor thread handles these on the GPU without touching the main thread. Any other property (like `top`, `left`, `width`, or `margin`) forces the browser back through the expensive stages of the [render pipeline](/logs/12-the-render-pipeline), blocking JavaScript and causing visible jank.
+  Animating only `transform` and `opacity` skips Layout and Paint entirely; the compositor thread handles these on the GPU without touching the main thread. Any other property (like `top`, `left`, `width`, or `margin`) forces the browser back through the expensive stages of the [render pipeline](/logs/12-the-render-pipeline), blocking JavaScript and causing visible jank.
 </Callout>
 
 ### Option B: Use `gsap.set()` to initialize before any tweens
@@ -168,7 +168,7 @@ This avoids the heuristic entirely. No detection, no rounding, no timing sensiti
 
 ### 1. Use `gsap.matchMedia()` to handle reduced motion
 
-GSAP doesn't respect `prefers-reduced-motion` by default, but it provides [`gsap.matchMedia()`](https://gsap.com/docs/v3/GSAP/gsap.matchMedia()) to handle it cleanly. It lets you run setup code only when a media query matches, and **automatically reverts animations** when conditions change — no manual cleanup needed:
+GSAP doesn't respect `prefers-reduced-motion` by default, but it provides [`gsap.matchMedia()`](https://gsap.com/docs/v3/GSAP/gsap.matchMedia()) to handle it cleanly. It lets you run setup code only when a media query matches, and **automatically reverts animations** when conditions change, with no manual cleanup needed:
 
 ```ts
 const mm = gsap.matchMedia()
@@ -194,7 +194,7 @@ mm.add(
 )
 ```
 
-This is better than a manual `window.matchMedia` check because `gsap.matchMedia()` ties the animation lifecycle to the query — if the user toggles reduced motion mid-session, GSAP reverts and re-runs the setup automatically.
+This is better than a manual `window.matchMedia` check because `gsap.matchMedia()` ties the animation lifecycle to the query: if the user toggles reduced motion mid-session, GSAP reverts and re-runs the setup automatically.
 
 ### 2. The blanket `transition-duration: 0.01ms` rule is too aggressive
 
@@ -209,7 +209,7 @@ It works for pure CSS sites. But when you mix CSS and JS animation systems, it c
 }
 ```
 
-Or better: don't use a blanket rule at all. Instead, handle reduced motion per-component using `gsap.matchMedia()` as shown above — it lets you decide per-animation whether to skip, simplify, or set `duration: 0`.
+Or better: don't use a blanket rule at all. Instead, handle reduced motion per-component using `gsap.matchMedia()` as shown above; it lets you decide per-animation whether to skip, simplify, or set `duration: 0`.
 
 ### 3. Test with reduced motion enabled from the start
 

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,10 @@
+{
+  "customContext": {
+    "rules": [
+      {
+        "rule": "Do not use em dashes (—) in prose, frontmatter descriptions, headings, or code comments. Replace them with a colon, semicolon, comma, parentheses, or by splitting into separate sentences, whichever reads most naturally. This keeps the writing in our own voice and avoids the em dash 'AI tell'. Regular hyphens (-) in compound words, slugs, and ranges are fine.",
+        "scope": ["content/**/*.mdx", "content/**/*.md", "**/*.mdx", "**/*.md"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Replaces em dashes (—) across the logs content with colons, semicolons,
and commas that read more naturally, and adds a greptile.json custom rule
so future em dashes in markdown content get flagged during review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015f6GgeHUZ5SGUoWgiB6JiN

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes em dashes (—) from three MDX log files and adds a `greptile.json` rule to flag them in future reviews. All replacements use colons, semicolons, or commas that read naturally in context, and a grep confirms no em dashes remain in the changed files.

- Fourteen em dash occurrences across `11-wtf-is-layout-thrashing.mdx`, `12-the-render-pipeline.mdx`, and `13-working-with-reduced-motion.mdx` are replaced with contextually appropriate punctuation (colons for introductory clauses, semicolons for closely related independent clauses, commas for light pauses).
- The new `greptile.json` custom rule scopes the em-dash check to `content/**/*.mdx` and `**/*.md`, ensuring the pattern is caught automatically going forward.
</details>

<h3>Confidence Score: 5/5</h3>

Pure content edits with no logic changes; all em dashes have been removed and replacements are natural and correct.

Every changed line is a prose punctuation substitution in MDX content files. No code logic, rendering, or data-fetching paths are touched. A grep confirms zero em dashes remain in the affected files.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/11-wtf-is-layout-thrashing.mdx | Two em dashes in the "Further reading" link descriptions replaced with colons; no issues found. |
| content/logs/12-the-render-pipeline.mdx | Eight em dashes replaced with colons, semicolons, and commas across frontmatter, code comments, and prose; all substitutions read naturally. |
| content/logs/13-working-with-reduced-motion.mdx | Four em dashes replaced with semicolons, a comma, and a colon; all substitutions read naturally. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Remove em dashes from logs and add Grept..."](https://github.com/joyco-studio/hub/commit/18c6e5463eafda3516c1c309f0ba8fb0b9ae2ddb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38062169)</sub>

**Context used:**

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))

<!-- /greptile_comment -->