### PR TITLE
Document Cluster gap token and bg-cascade identifiers

### DIFF
--- a/content/components/cluster.mdx
+++ b/content/components/cluster.mdx
@@ -38,7 +38,7 @@ The cascade is wired through three identifiers:
 }
 ```
 
-Because the selector uses `:where()`, it has zero specificity — any `bg-*` utility on a child overrides it without a fight. Target `[data-slot='cluster']` or `--cluster-bg` if you need to extend or override this mechanism.
+Because the selector uses `:where()`, it has zero specificity, so any `bg-*` utility on a child overrides it without a fight. Target `[data-slot='cluster']` or `--cluster-bg` if you need to extend or override this mechanism.
 
 ## Usage
 

--- a/content/components/cluster.mdx
+++ b/content/components/cluster.mdx
@@ -22,7 +22,7 @@ This replaces the traditional "Card" pattern (wrapper with bg + padding). In JOY
 
 ### The gap
 
-The gap between cluster children is the design-system token `--gap: 0.25rem` (4px), applied via the `gap-gap` Tailwind utility (the base class on every Cluster). This tight spacing is what produces the bento/console look — children read as adjacent panels separated by a hairline of background, not as loosely spaced elements.
+The gap between cluster children is the design-system token `--gap: 0.25rem` (4px), applied via the `gap-gap` Tailwind utility (the base class on every Cluster). This tight spacing is what produces the bento/console look: children read as adjacent panels separated by a hairline of background, not as loosely spaced elements.
 
 ### The bg cascade
 

--- a/content/components/cluster.mdx
+++ b/content/components/cluster.mdx
@@ -20,6 +20,26 @@ A Cluster is an **invisible layout scaffold**. It has no background — it only 
 
 This replaces the traditional "Card" pattern (wrapper with bg + padding). In JOYCO's design system, **containers are transparent — children own their own backgrounds**.
 
+### The gap
+
+The gap between cluster children is the design-system token `--gap: 0.25rem` (4px), applied via the `gap-gap` Tailwind utility (the base class on every Cluster). This tight spacing is what produces the bento/console look — children read as adjacent panels separated by a hairline of background, not as loosely spaced elements.
+
+### The bg cascade
+
+The cascade is wired through three identifiers:
+
+1. The Cluster carries `data-slot="cluster"`.
+2. The `bg` prop sets the `--cluster-bg` CSS variable on the Cluster (e.g. `[--cluster-bg:var(--color-muted)]`).
+3. A single global, zero-specificity rule applies that variable to every direct child:
+
+```css
+:where([data-slot='cluster'] > *) {
+  background-color: var(--cluster-bg, transparent);
+}
+```
+
+Because the selector uses `:where()`, it has zero specificity — any `bg-*` utility on a child overrides it without a fight. Target `[data-slot='cluster']` or `--cluster-bg` if you need to extend or override this mechanism.
+
 ## Usage
 
 ```tsx


### PR DESCRIPTION
## What

Documents two implementation facts that were missing from the Cluster doc (`content/components/cluster.mdx`), added as subsections under **Core Concept**:

1. **The gap** — the spacing between cluster children is the `--gap: 0.25rem` (4px) token, applied via the `gap-gap` Tailwind utility. Notes that this tight spacing is what produces the bento/console look. Previously the doc only said Cluster "provides gap" without stating the value or utility name.
2. **The bg cascade** — names the three identifiers the cascade is wired through: `data-slot="cluster"`, the `--cluster-bg` CSS variable, and the global zero-specificity rule `:where([data-slot='cluster'] > *) { background-color: var(--cluster-bg, transparent); }`. Useful for anyone targeting or overriding the mechanism.

## Verification

All values verified against source:
- `app/styles/globals.css:154` — `--gap: 0.25rem`
- `app/styles/globals.css:93` — `--spacing-gap: var(--gap)` (the chain that generates the `gap-gap` utility)
- `app/styles/globals.css:148-150` — the global cascade rule
- `components/ui/cluster.tsx:7,29-30,60` — `gap-gap` base class, `--cluster-bg` variants, `data-slot="cluster"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents two previously undocumented implementation details of the Cluster component: the `--gap` spacing token and the `bg-cascade` mechanism. The new content is accurate and well-structured.

- Adds a "The gap" subsection explaining the `--gap: 0.25rem` token and the `gap-gap` Tailwind utility.
- Adds a "The bg cascade" subsection naming the three identifiers (`data-slot="cluster"`, `--cluster-bg`, and the global `:where()` rule) and explaining how the zero-specificity cascade works.
</details>

<h3>Confidence Score: 4/5</h3>

Documentation-only change; safe to merge after addressing the style fixes.

The change is purely additive documentation with no runtime impact. The two em dashes introduced in the new prose are the only findings.

content/components/cluster.mdx — two em dashes in the newly added paragraphs on lines 25 and 41.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/components/cluster.mdx | Adds two subsections documenting the gap token and bg-cascade identifiers; content is accurate but two em dashes were introduced in violation of the style rule. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
content/components/cluster.mdx:25
Two em dashes were introduced in the new sections, which violates the no-em-dash rule. A second occurrence appears on line 41 ("it has zero specificity — any `bg-*` utility"). Both should be replaced with a colon or comma construction.

```suggestion
The gap between cluster children is the design-system token `--gap: 0.25rem` (4px), applied via the `gap-gap` Tailwind utility (the base class on every Cluster). This tight spacing is what produces the bento/console look: children read as adjacent panels separated by a hairline of background, not as loosely spaced elements.
```

### Issue 2 of 2
content/components/cluster.mdx:41
Second em dash occurrence in the new content (see also line 25).

```suggestion
Because the selector uses `:where()`, it has zero specificity, so any `bg-*` utility on a child overrides it without a fight. Target `[data-slot='cluster']` or `--cluster-bg` if you need to extend or override this mechanism.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Document Cluster gap token and bg-cascad..."](https://github.com/joyco-studio/hub/commit/cef39b44a0dc9e2711b4d0b984e6b53b07079f27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38135542)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))

<!-- /greptile_comment -->