### PR TITLE
Expand CategoryIndex into a markdown list in .md output

### DIFF
--- a/lib/source.ts
+++ b/lib/source.ts
@@ -87,17 +87,21 @@ function getCategoryPages(category: string) {
  * one line per entry, so non-browser consumers (LLMs, curl, scripts) can scan
  * titles and links without executing the React component.
  */
+const escapeMarkdownLinkText = (text: string) =>
+  text.replace(/[[\]()]/g, '\\$&')
+
 function renderCategoryIndexAsMarkdown(category: string): string {
   const pages = getCategoryPages(category)
 
   return pages
     .map((page) => {
       const logNumber = getLogNumber(page.slugs)
-      const title = logNumber
+      const rawTitle = logNumber
         ? stripLogPrefixFromTitle(page.data.title, logNumber)
         : page.data.title
+      const title = escapeMarkdownLinkText(rawTitle)
       const description = page.data.description
-        ? ` — ${page.data.description}`
+        ? ` — ${escapeMarkdownLinkText(page.data.description)}`
         : ''
       return `- [${title}](${page.url})${description}`
     })

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -54,6 +54,59 @@ export function getPageImage(page: InferPageType<typeof source>) {
   }
 }
 
+/**
+ * Resolve a category's pages in the same order the `CategoryIndex` component
+ * renders them, so the LLM/raw markdown matches what a browser sees.
+ */
+function getCategoryPages(category: string) {
+  const pages = source
+    .getPages()
+    .filter((page) => page.slugs[0] === category && page.slugs.length > 1)
+
+  // Match the page-tree (meta.json / creation-date) order used in the sidebar.
+  const folder = getTopLevelFolder(category)
+  const order = (folder?.children ?? [])
+    .filter((child) => child.type === 'page' && child.url)
+    .map((child) => child.url!)
+
+  if (order.length > 0) {
+    const orderMap = new Map(order.map((url, i) => [url, i]))
+    pages.sort(
+      (a, b) =>
+        (orderMap.get(a.url) ?? Infinity) - (orderMap.get(b.url) ?? Infinity)
+    )
+  }
+
+  if (category === 'logs') pages.reverse()
+
+  return pages
+}
+
+/**
+ * Render a `<CategoryIndex category="..." />` MDX tag as a plain markdown list,
+ * one line per entry, so non-browser consumers (LLMs, curl, scripts) can scan
+ * titles and links without executing the React component.
+ */
+function renderCategoryIndexAsMarkdown(category: string): string {
+  const pages = getCategoryPages(category)
+
+  return pages
+    .map((page) => {
+      const logNumber = getLogNumber(page.slugs)
+      const title = logNumber
+        ? stripLogPrefixFromTitle(page.data.title, logNumber)
+        : page.data.title
+      const description = page.data.description
+        ? ` — ${page.data.description}`
+        : ''
+      return `- [${title}](${page.url})${description}`
+    })
+    .join('\n')
+}
+
+const categoryIndexRegex =
+  /<CategoryIndex[\s\S]*?category="([^"]+)"[\s\S]*?(?:\/>|<\/CategoryIndex>)/g
+
 export async function getLLMText(page: InferPageType<typeof source>) {
   const llmCompanion = path.join(
     process.cwd(),
@@ -67,7 +120,13 @@ export async function getLLMText(page: InferPageType<typeof source>) {
   }
 
   const raw = await page.data.getText('raw')
-  const processed = processMdxForLLMs(raw)
+  let processed = processMdxForLLMs(raw)
+
+  // Expand `<CategoryIndex category="..." />` into a real markdown list so the
+  // raw/.md representation lists every entry instead of an opaque JSX tag.
+  processed = processed.replace(categoryIndexRegex, (_match, category) =>
+    renderCategoryIndexAsMarkdown(category)
+  )
 
   let libraryBody = ''
   if (page.data.type === 'library' && page.data.repo) {


### PR DESCRIPTION
## Problem

The `.md` / raw representation of category index pages — `/logs.md`, `/components.md`, `/toolbox.md` — served the literal unrendered JSX:

```
# Logs

<CategoryIndex category="logs" />
```

Fetched as raw markdown (no JS execution), `<CategoryIndex>` never expands, so any non-browser consumer (LLM agents, `curl`, scripts) saw zero entries. Individual `/logs/NN-slug.md` pages were fine — only the category indexes were opaque.

## Fix

`getLLMText` (in `lib/source.ts`) now replaces any `<CategoryIndex category="..." />` tag with a real markdown list, one line per entry:

```
# Logs

- [Derive, Don't Mutate](/logs/15-derive-dont-mutate) — When one value has many writers…
- [Phantom Merge Conflicts](/logs/14-phantom-merge-conflicts) — Why git shows conflicts…
… (all 15, reverse-chronological)
```

Each line is `- [title](url) — description`. The logic reproduces the component's behavior: page-tree (meta.json / creation-date) ordering, the `logs` reversal, and log-number prefix stripping from titles. Descriptions are included where present (helps relevance-matching).

The fix is driven by the `category` prop in the MDX, so it's generic — any current or future `<CategoryIndex>` page expands automatically. The three existing index pages (`components`, `toolbox`, `logs`) already have `.md` rewrites in `next.config.ts`, so all are covered.

The **HTML pages are unchanged** — they keep rendering the interactive `<CategoryIndex>` component. This only changes what the `.md` / raw route serves.

## Verification

- `tsc --noEmit` clean
- `next build` succeeds
- Fetched live from the dev server:

| Route | Status | Content-Type | Entries | Leftover tags |
|---|---|---|---|---|
| `/logs.md` | 200 | `text/markdown` | 15 | 0 |
| `/components.md` | 200 | `text/markdown` | 25 | 0 |
| `/toolbox.md` | 200 | `text/markdown` | 20 | 0 |

- `/logs` HTML still served as `text/html` with the interactive component intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `.md` / raw-text output for category index pages (`/logs.md`, `/components.md`, `/toolbox.md`) by replacing the unrendered `<CategoryIndex category="..." />` JSX tag with a proper markdown list at the point where `getLLMText` assembles the response. HTML rendering is completely unaffected.

- `getCategoryPages` mirrors the `CategoryIndex` component's ordering logic: page-tree order from `meta.json`/creation-date, with a reversal for `logs`.
- `renderCategoryIndexAsMarkdown` maps each page to `- [title](url) — description`, with `escapeMarkdownLinkText` guarding `[`, `]`, `(`, `)` in titles and descriptions.
- The module-level `/g` regex is only consumed via `String.prototype.replace()`, which resets `lastIndex` unconditionally, so there is no stateful-regex hazard across concurrent calls.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is isolated to `getLLMText` and does not touch HTML rendering or any data-write path.

The new code correctly reproduces the `CategoryIndex` component's ordering, escapes markdown special characters in link text, and is only triggered by the existing `<CategoryIndex>` tag in MDX. There are no mutations to page data, no new external calls, and the regex is used exclusively with `replace()` so `lastIndex` state is not a concern.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/source.ts | Adds `getCategoryPages`, `renderCategoryIndexAsMarkdown`, and a module-level regex to expand `<CategoryIndex category="..." />` tags into a real markdown list inside `getLLMText`. Logic is sound: page-tree ordering, logs reversal, log-number prefix stripping, and markdown link-text escaping are all handled correctly. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["greptile review"](https://github.com/joyco-studio/hub/commit/c3b2b8e2e0c3b96c144c7ee78716ff5676ab38c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38138135)</sub>

<!-- /greptile_comment -->