### PR TITLE
Add log 16: Phased State as Tagged Unions pattern

### DIFF
--- a/content/logs/16-phased-state-tagged-unions.mdx
+++ b/content/logs/16-phased-state-tagged-unions.mdx
@@ -62,7 +62,7 @@ A `switch` over `phase` with no `default` forces you to handle every variant. Ad
 
 ### 4. Transitions become the unit of meaning (edge detection)
 
-This is the deepest payoff. Because the whole machine is one value that gets replaced, you can diff **old vs new** and react to the **transition**, not the state. `InspectManager.sync` keeps the previous id and branches on the edge:
+This is the deepest payoff. Because the whole machine is one value that gets replaced, you can diff **old vs new** and react to the **transition**, not the state. The change itself becomes *first-class*: a real value you can hold in a variable, compare, and branch on, instead of an event you have to reconstruct from a pile of flags after the fact. `InspectManager.sync` keeps the previous id and branches on the edge:
 
 ```ts
 const next = inspectedId(state.ctx)

--- a/content/logs/16-phased-state-tagged-unions.mdx
+++ b/content/logs/16-phased-state-tagged-unions.mdx
@@ -6,7 +6,7 @@ author: 'matiasperz'
 
 A **phase** is a named mode a thing can be in, where the data that exists, and the operations that make sense, depend on which mode you're in. You model it as a **discriminated union**: one variant per phase, each carrying exactly the fields that phase needs and nothing it doesn't.
 
-The inspect lifecycle from our game code is the canonical example. Here's the union:
+Imagine the item-inspection code for a game: you pick something up, hold it, look it over, then put it down. That lifecycle is the canonical example. Here's the union:
 
 ```ts
 type Inspect =

--- a/content/logs/16-phased-state-tagged-unions.mdx
+++ b/content/logs/16-phased-state-tagged-unions.mdx
@@ -1,6 +1,6 @@
 ---
 title: '16 - Phased State: Modes as Tagged Unions'
-description: Model mutually-exclusive modes as a discriminated union keyed on a phase tag, expose it through derived selectors, and drive behavior off old to new transitions, so illegal states can't exist and "what just changed" becomes a first-class question.
+description: Model a thing's modes as a tagged union instead of a bag of booleans, so illegal states can't exist and you can react to what just changed.
 author: 'matiasperz'
 ---
 

--- a/content/logs/16-phased-state-tagged-unions.mdx
+++ b/content/logs/16-phased-state-tagged-unions.mdx
@@ -1,0 +1,123 @@
+---
+title: '16 - Phased State: Modes as Tagged Unions'
+description: Model mutually-exclusive modes as a discriminated union keyed on a phase tag, expose it through derived selectors, and drive behavior off old to new transitions, so illegal states can't exist and "what just changed" becomes a first-class question.
+author: 'matiasperz'
+---
+
+A **phase** is a named mode a thing can be in, where the data that exists, and the operations that make sense, depend on which mode you're in. You model it as a **discriminated union**: one variant per phase, each carrying exactly the fields that phase needs and nothing it doesn't.
+
+The inspect lifecycle from our game code is the canonical example. Here's the union:
+
+```ts
+type Inspect =
+  | { phase: 'idle' }                                       // nothing held
+  | { phase: 'inspecting'; element: ElementId }             // manual hold
+  | { phase: 'revealing';  element: ElementId }             // first-pickup reveal
+  | { phase: 'exiting';    element: ElementId; reveal: boolean } // teardown
+```
+
+The `phase` string is the **discriminant**. Once you've narrowed on it, the type of the rest of the object is known. `idle` has no `element`, and that is the point: there is no element when nothing is held, so the field does not exist in that branch.
+
+## What it replaces: the anti-pattern
+
+The naive version is a bag of independent fields:
+
+```ts
+// DON'T
+interface Inspect {
+  isInspecting: boolean
+  isRevealing: boolean
+  isExiting: boolean
+  element: ElementId | null
+  reveal: boolean
+}
+```
+
+Five booleans/nullables = 32 representable combinations, but only **4** are legal. I call this the "Bag-of-booleans". What does `{ isInspecting: true, isExiting: true, element: null }` mean? Nothing, but the type permits it, so every reader has to defend against it and every writer can accidentally produce it. The bug surface is exactly the gap between *representable* states and *valid* states.
+
+The tagged union closes that gap: **illegal states are unrepresentable.** You cannot construct an `exiting` value without an `element`, and you cannot read `element` off an `idle` value. The compiler enforces the state chart.
+
+## The five things it buys you
+
+### 1. Data is scoped to the phase that owns it
+
+`reveal: boolean` exists only on `exiting`, because "was this a discovery reveal?" is only a meaningful question while tearing one down. You never carry a field that is `null`/irrelevant most of the time. The shape documents itself: read the union and you know the lifecycle.
+
+### 2. One source of truth, queried through derived accessors
+
+Consumers never poke at raw phases. They read a **selector** that collapses the machine into the question they care about:
+
+```ts
+// game/state/inspect.ts
+export const inspectedId = (ctx) =>
+  ctx.inspect.phase === 'inspecting' || ctx.inspect.phase === 'revealing'
+    ? ctx.inspect.element : null
+```
+
+"Which element is the user actively looking at?" Two phases answer yes; the rest answer `null`. The crucial part: **the encoding can change without touching callers.** Split `inspecting` into `inspecting`/`zooming` later and you edit this one function, and every consumer stays correct. The phases are an implementation detail behind a stable derived API.
+
+### 3. Exhaustiveness: the compiler finds your missing cases
+
+A `switch` over `phase` with no `default` forces you to handle every variant. Add a new phase and every unhandled `switch` becomes a compile error pointing at the code that forgot it. The state chart and the code that drives it cannot silently drift apart.
+
+### 4. Transitions become the unit of meaning (edge detection)
+
+This is the deepest payoff. Because the whole machine is one value that gets replaced, you can diff **old vs new** and react to the **transition**, not the state. `InspectManager.sync` keeps the previous id and branches on the edge:
+
+```ts
+const next = inspectedId(state.ctx)
+if (next === this.lastInspecting) return   // no edge → nothing to do
+const was = this.lastInspecting
+this.lastInspecting = next
+// ... branch on the (was → next) edge
+```
+
+Three transitions, three behaviors:
+
+| Edge              | Meaning              | Behavior          |
+| ----------------- | -------------------- | ----------------- |
+| `null → X`        | fresh open           | approach (fly-in) |
+| `X → null`        | close                | ease back         |
+| `X → Y`           | swap without closing | instant in place  |
+
+The polaroid arrow "instant swap" fell out of this for free. `was != null && next != null` is a *watertight* signal for "swapped without closing," because the machine can only produce that edge one way: an `openInspect` effect fired while `phase` was already `inspecting`. You are not tracking a separate `isSwapping` flag that can desync; the flag is **implied by the shape of the transition**. Bag-of-booleans state cannot do this, because there is no single value to diff, so "what just changed?" is not answerable.
+
+### 5. Phases gate which operations are even legal
+
+`InspectManager.onPointerDown` starts a drag only when `phase === 'inspecting'` (not during a `revealing` showcase spin, not while `exiting`). The phase *is* the guard. Instead of scattering `if (isInspecting && !isExiting && !isRevealing)` everywhere, the answer is one discriminant check. Operations attach to the phases where they make sense.
+
+## A generic template
+
+The pattern recurs wherever a thing has a lifecycle. Each gives you: no illegal combos, phase-scoped data, exhaustive handling, and, if you keep the previous value, transition detection.
+
+```ts
+// async data
+type Resource<T> =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'success'; data: T }
+  | { phase: 'error'; message: string }   // no `data` here, can't render stale data by accident
+
+// a media player
+type Playback =
+  | { phase: 'stopped' }
+  | { phase: 'playing'; trackId: string; startedAt: number }
+  | { phase: 'paused';  trackId: string; positionMs: number }   // position only matters when paused
+
+// a wizard / checkout
+type Checkout =
+  | { phase: 'cart' }
+  | { phase: 'shipping'; cart: Cart }
+  | { phase: 'payment';  cart: Cart; address: Address }   // address exists only once collected
+  | { phase: 'done';     orderId: string }
+```
+
+## When *not* to reach for it
+
+It is overkill when fields are genuinely independent: a settings record (`volume`, `theme`, `language`) has no field that constrains another, so it is just a record. The pattern earns its keep when **the presence of one field depends on the value of another**, or when **the modes are mutually exclusive** and you keep writing `if (a && !b && !c)`. That `&&`-soup is the smell that says "these booleans are secretly one phase."
+
+This is also the other half of [Derive, Don't Mutate](/logs/15-derive-dont-mutate). That post handles N independent sources each holding a simultaneous stake in one value; the moment those "sources" turn out to be mutually-exclusive *modes*, you're no longer resolving a fight, you're modeling a state machine, and this is the shape it wants.
+
+## The rule
+
+> Model mutually-exclusive modes as a discriminated union keyed on a `phase` tag, expose it through derived selectors, and drive behavior off old→new transitions, so illegal states can't exist, data lives only where it's meaningful, and "what just changed" becomes a first-class, diffable question.

--- a/content/logs/16-phased-state-tagged-unions.mdx
+++ b/content/logs/16-phased-state-tagged-unions.mdx
@@ -48,7 +48,7 @@ The tagged union closes that gap: **illegal states are unrepresentable.** You ca
 Consumers never poke at raw phases. They read a **selector** that collapses the machine into the question they care about:
 
 ```ts
-// game/state/inspect.ts
+// a derived selector over the state
 export const inspectedId = (ctx) =>
   ctx.inspect.phase === 'inspecting' || ctx.inspect.phase === 'revealing'
     ? ctx.inspect.element : null
@@ -62,7 +62,7 @@ A `switch` over `phase` with no `default` forces you to handle every variant. Ad
 
 ### 4. Transitions become the unit of meaning (edge detection)
 
-This is the deepest payoff. Because the whole machine is one value that gets replaced, you can diff **old vs new** and react to the **transition**, not the state. The change itself becomes *first-class*: a real value you can hold in a variable, compare, and branch on, instead of an event you have to reconstruct from a pile of flags after the fact. `InspectManager.sync` keeps the previous id and branches on the edge:
+This is the deepest payoff. Because the whole machine is one value that gets replaced, you can diff **old vs new** and react to the **transition**, not the state. The change itself becomes *first-class*: a real value you can hold in a variable, compare, and branch on, instead of an event you have to reconstruct from a pile of flags after the fact. A small sync loop keeps the previous id and branches on the edge:
 
 ```ts
 const next = inspectedId(state.ctx)
@@ -80,11 +80,11 @@ Three transitions, three behaviors:
 | `X → null`        | close                | ease back         |
 | `X → Y`           | swap without closing | instant in place  |
 
-The polaroid arrow "instant swap" fell out of this for free. `was != null && next != null` is a *watertight* signal for "swapped without closing," because the machine can only produce that edge one way: an `openInspect` effect fired while `phase` was already `inspecting`. You are not tracking a separate `isSwapping` flag that can desync; the flag is **implied by the shape of the transition**. Bag-of-booleans state cannot do this, because there is no single value to diff, so "what just changed?" is not answerable.
+The "instant swap" behavior fell out of this for free. `was != null && next != null` is a *watertight* signal for "swapped without closing," because the machine can only produce that edge one way: a new item opened while one was already held. You are not tracking a separate `isSwapping` flag that can desync; the flag is **implied by the shape of the transition**. Bag-of-booleans state cannot do this, because there is no single value to diff, so "what just changed?" is not answerable.
 
 ### 5. Phases gate which operations are even legal
 
-`InspectManager.onPointerDown` starts a drag only when `phase === 'inspecting'` (not during a `revealing` showcase spin, not while `exiting`). The phase *is* the guard. Instead of scattering `if (isInspecting && !isExiting && !isRevealing)` everywhere, the answer is one discriminant check. Operations attach to the phases where they make sense.
+A pointer-down handler starts a drag only when `phase === 'inspecting'` (not during a `revealing` showcase spin, not while `exiting`). The phase *is* the guard. Instead of scattering `if (isInspecting && !isExiting && !isRevealing)` everywhere, the answer is one discriminant check. Operations attach to the phases where they make sense.
 
 ## A generic template
 


### PR DESCRIPTION
Adds a new documentation page explaining the **Phased State** pattern, which models mutually-exclusive modes as discriminated unions to eliminate illegal state combinations and enable transition-based behavior.

## Summary

This log documents a core state management pattern used throughout the codebase: representing lifecycle phases (idle, loading, inspecting, etc.) as tagged unions rather than bags of independent boolean flags. The pattern ensures type safety, scopes data to relevant phases, and enables edge detection by diffing old vs. new state.

## Key Content

- **The pattern**: Discriminated unions with a `phase` discriminant, one variant per mode, carrying only the fields that mode needs
- **The problem it solves**: Replaces the "bag-of-booleans" anti-pattern that permits illegal state combinations
- **Five concrete benefits**:
  1. Data scoped to the phase that owns it
  2. One source of truth queried through derived selectors
  3. Exhaustiveness checking via compiler
  4. Transitions as a unit of meaning (edge detection)
  5. Operations gated by phase
- **Real examples**: `Inspect` lifecycle from the game code, plus generic templates for `Resource<T>`, `Playback`, and `Checkout`
- **When to use it**: When field presence depends on another field's value, or when you're writing `if (a && !b && !c)` boolean soup

## Implementation Notes

The page includes concrete code examples showing the anti-pattern vs. the solution, a transition table demonstrating edge-based behavior, and guidance on when the pattern is overkill (independent fields like settings records).

https://claude.ai/code/session_01GhN8wVTyyVR1hgkkjy44BV

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new log page about the Phased State pattern. The main changes are:

- New MDX page for `16-phased-state-tagged-unions`.
- Frontmatter with title, description, and author.
- TypeScript examples for tagged unions and lifecycle states.
- Transition table and link to the previous derive-state log.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new MDX page matches the existing content and log conventions.
- The linked previous log exists and the page should be discoverable by the log listing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/16-phased-state-tagged-unions.mdx | Adds a new MDX log page with valid frontmatter, log naming, code fences, table syntax, and cross-linking. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add log 16: Phased State, modes as tagge..."](https://github.com/joyco-studio/hub/commit/bf50dd276c56dde845df25d948c18942d5dec970) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39931305)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))
- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->