### PR TITLE
docs: add msdfgen toolbox page

### DIFF
--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -23,6 +23,13 @@ SDFs.
 The payoff: one small texture renders crisp text, logos, or icons at any zoom level, with cheap
 shader effects like outlines, glows, and animated fills essentially for free.
 
+<Callout type="info">
+  Generating an atlas for a **whole font** rather than a single shape? Skip the CLI and use
+  [msdf-font-generator.leomouraire.com](https://msdf-font-generator.leomouraire.com), a web tool
+  that bakes the MSDF atlas and emits the JSON manifest (glyph metrics + UVs) in the browser. The
+  rest of this page covers the CLI flow we use for the custom text + logo texture.
+</Callout>
+
 <Image
   src=""
   alt="Side-by-side comparison of the same glyph rendered from a regular bitmap (blurry when scaled up) versus an MSDF texture (crisp edges at the same zoom). Make the scaling artifacts on the bitmap obvious."

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -1,0 +1,131 @@
+---
+title: msdfgen
+description: A CLI for generating multi-channel signed distance field (MSDF) textures from vector shapes.
+links:
+  [
+    {
+      label: 'GitHub',
+      href: 'https://github.com/Chlumsky/msdfgen',
+    },
+  ]
+---
+
+## What is msdfgen?
+
+[msdfgen](https://github.com/Chlumsky/msdfgen) turns a vector shape (an SVG path, a glyph, a
+font) into a **multi-channel signed distance field** texture. A regular bitmap stores color per
+pixel, so it blurs the moment you scale it up. An SDF instead stores, per pixel, the *distance*
+to the nearest edge of the shape — which a shader can resolve back into a razor-sharp outline at
+any size. The "multi-channel" part packs three distance fields into the RGB channels so that
+**sharp corners survive** instead of getting rounded off, which is the weak spot of single-channel
+SDFs.
+
+The payoff: one small texture renders crisp text, logos, or icons at any zoom level, with cheap
+shader effects like outlines, glows, and animated fills essentially for free.
+
+<Image
+  src=""
+  alt="Side-by-side comparison of the same glyph rendered from a regular bitmap (blurry when scaled up) versus an MSDF texture (crisp edges at the same zoom). Make the scaling artifacts on the bitmap obvious."
+  width={1800}
+  height={1000}
+/>
+
+We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader —
+see the snippet at the bottom for how the GPU reconstructs the edge.
+
+<Image
+  src=""
+  alt="The generated MSDF PNG itself: a shape rendered with the characteristic red/green/blue fringing around every edge on a black background. Show that it looks 'wrong' to the eye but encodes the distance data."
+  width={1024}
+  height={1024}
+/>
+
+## Installation
+
+The repo ships a CMake build and Vcpkg/Homebrew packages. The quickest paths:
+
+```bash title="macOS (Homebrew)"
+brew install msdfgen
+```
+
+```bash title="From source (CMake + Vcpkg)"
+git clone https://github.com/Chlumsky/msdfgen
+cd msdfgen
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+```
+
+Once installed you should have the `msdfgen` binary on your `PATH`. Verify with `msdfgen --help`.
+
+## The merge step (gotcha)
+
+`msdfgen` only reads the **last** `<path>` element from an SVG. Design tools (Figma, Illustrator)
+export each glyph or shape as its own `<path>`, so before generating you have to concatenate all
+the `d` attributes into a single `<path>`, separated by spaces.
+
+```xml
+<!-- Before: N paths (typical Figma/Illustrator export) -->
+<path d="M30.59..." fill="white"/>
+<path d="M50.11..." fill="white"/>
+<path d="M25.51..." fill="white"/>
+
+<!-- After: 1 path (required for msdfgen) -->
+<path d="M30.59... M50.11... M25.51..." fill="white"/>
+```
+
+A small script does it for you:
+
+```bash title="merge-paths.sh"
+python3 -c "
+import re
+with open('MSDF.svg') as f: svg = f.read()
+paths = re.findall(r'd=\"([^\"]+)\"', svg)
+merged = ' '.join(paths)
+out = f'<svg width=\"512\" height=\"512\" viewBox=\"0 0 512 512\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<path d=\"{merged}\" fill=\"white\"/>\n</svg>'
+with open('MSDF-merged.svg', 'w') as f: f.write(out)
+print(f'Merged {len(paths)} paths')
+"
+```
+
+<Callout type="warn">
+  Always merge **before** exporting. If you re-export the SVG from a design tool, the paths split
+  again and you have to merge a second time.
+</Callout>
+
+## Recommended generation flow
+
+```bash
+cd public/textures
+msdfgen msdf -svg MSDF-merged.svg -o msdf.png -dimensions 512 512 -pxrange 8 -scale 1 -translate 0 0
+rm MSDF-merged.svg
+```
+
+| Flag          | Value     | Why                                                                                                                                                       |
+| ------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `msdf`        | mode      | Multi-channel SDF — preserves sharp corners via RGB channel separation                                                                                     |
+| `-dimensions` | `512 512` | Matches the SVG viewBox and existing texture size                                                                                                          |
+| `-pxrange`    | `8`       | Pixel range of the distance gradient. Higher = more room for shader effects (outline, glow). `8` works well for the glyph density in this texture          |
+| `-scale`      | `1`       | 1:1 mapping — 1 SVG unit = 1 pixel. **Do not use `-autoframe`**: it rescales and adds padding, shifting UVs and breaking the shader's crop rects           |
+| `-translate`  | `0 0`     | No offset. msdfgen handles the SVG y-down → image y-down conversion correctly when reading from an SVG                                                      |
+
+### Verify the output
+
+Open the PNG and confirm:
+
+- The shapes are positioned where the SVG placed them.
+- There's **distinct red/green/blue fringing** around every edge — the MSDF signature.
+- The background is solid black where no shape exists.
+
+It won't look "clean" to the naked eye, and that's expected — the fragment shader reconstructs
+crisp edges by taking the **median** of the RGB channels.
+
+## How the shader uses it
+
+```glsl
+vec3 s = texture2D(uMSDF, vUv).rgb;
+float dist = median(s.r, s.g, s.b);
+float fill = smoothstep(0.5 - fwidth(dist), 0.5 + fwidth(dist), dist);
+```
+
+The `median` of the three channels recovers the true signed distance, and `smoothstep` at the
+`0.5` threshold produces a pixel-perfect edge at any scale.

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -40,11 +40,14 @@ shader effects like outlines, glows, and animated fills essentially for free.
 We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader.
 See the snippet at the bottom for how the GPU reconstructs the edge.
 
-<Image
-  src="https://r2.joyco.studio/hub/images/joyco-msdf.svg"
-  alt="The JOYCO logo rendered from its MSDF texture."
-  width={208}
-  height={208}
+<Video
+  src="https://r2.joyco.studio/hub/videos/msdf-three.mp4"
+  autoPlay
+  loop
+  muted
+  playsInline
+  width={1660}
+  height={1080}
 />
 
 ## Installation

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -33,18 +33,18 @@ shader effects like outlines, glows, and animated fills essentially for free.
 <Image
   src="https://r2.joyco.studio/hub/images/msdf-svg-comp.png"
   alt="Side-by-side comparison of a shape rendered from a plain raster versus an MSDF texture, showing the MSDF staying crisp where the raster breaks down."
-  width={1786}
-  height={992}
+  width={1828}
+  height={1028}
 />
 
 We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader.
 See the snippet at the bottom for how the GPU reconstructs the edge.
 
 <Image
-  src=""
-  alt="The generated MSDF PNG itself: a shape rendered with the characteristic red/green/blue fringing around every edge on a black background. Show that it looks 'wrong' to the eye but encodes the distance data."
-  width={1024}
-  height={1024}
+  src="https://r2.joyco.studio/hub/images/joyco-msdf.svg"
+  alt="The JOYCO logo rendered from its MSDF texture."
+  width={208}
+  height={208}
 />
 
 ## Installation

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -31,10 +31,10 @@ shader effects like outlines, glows, and animated fills essentially for free.
 </Callout>
 
 <Image
-  src=""
-  alt="Side-by-side comparison of the same glyph rendered from a regular bitmap (blurry when scaled up) versus an MSDF texture (crisp edges at the same zoom). Make the scaling artifacts on the bitmap obvious."
-  width={1800}
-  height={1000}
+  src="https://r2.joyco.studio/hub/images/msdf-svg-comp.png"
+  alt="Side-by-side comparison of a shape rendered from a plain raster versus an MSDF texture, showing the MSDF staying crisp where the raster breaks down."
+  width={1786}
+  height={992}
 />
 
 We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader.

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -122,7 +122,7 @@ Open the PNG and confirm:
 It won't look "clean" to the naked eye, and that's expected. The fragment shader reconstructs
 crisp edges by taking the **median** of the RGB channels.
 
-## How the shader uses it
+## How a fragment shader renders msdf
 
 ```glsl
 vec3 s = texture2D(uMSDF, vUv).rgb;

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -121,17 +121,6 @@ rm MSDF-merged.svg
 | `-scale`      | `1`       | 1:1 mapping, so 1 SVG unit = 1 pixel. **Do not use `-autoframe`**: it rescales and adds padding, shifting UVs and breaking the shader's crop rects         |
 | `-translate`  | `0 0`     | No offset. msdfgen handles the SVG y-down to image y-down conversion correctly when reading from an SVG                                                     |
 
-### Verify the output
-
-Open the PNG and confirm:
-
-- The shapes are positioned where the SVG placed them.
-- There's **distinct red/green/blue fringing** around every edge, the MSDF signature.
-- The background is solid black where no shape exists.
-
-It won't look "clean" to the naked eye, and that's expected. The fragment shader reconstructs
-crisp edges by taking the **median** of the RGB channels.
-
 ## How a fragment shader renders msdf
 
 ```glsl

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -15,7 +15,7 @@ links:
 [msdfgen](https://github.com/Chlumsky/msdfgen) turns a vector shape (an SVG path, a glyph, a
 font) into a **multi-channel signed distance field** texture. A regular bitmap stores color per
 pixel, so it blurs the moment you scale it up. An SDF instead stores, per pixel, the *distance*
-to the nearest edge of the shape — which a shader can resolve back into a razor-sharp outline at
+to the nearest edge of the shape, which a shader can resolve back into a razor-sharp outline at
 any size. The "multi-channel" part packs three distance fields into the RGB channels so that
 **sharp corners survive** instead of getting rounded off, which is the weak spot of single-channel
 SDFs.
@@ -30,8 +30,8 @@ shader effects like outlines, glows, and animated fills essentially for free.
   height={1000}
 />
 
-We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader —
-see the snippet at the bottom for how the GPU reconstructs the edge.
+We use it to bake the text + logo atlas that the Three.js scene samples in its fragment shader.
+See the snippet at the bottom for how the GPU reconstructs the edge.
 
 <Image
   src=""
@@ -102,21 +102,21 @@ rm MSDF-merged.svg
 
 | Flag          | Value     | Why                                                                                                                                                       |
 | ------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `msdf`        | mode      | Multi-channel SDF — preserves sharp corners via RGB channel separation                                                                                     |
+| `msdf`        | mode      | Multi-channel SDF. Preserves sharp corners via RGB channel separation                                                                                      |
 | `-dimensions` | `512 512` | Matches the SVG viewBox and existing texture size                                                                                                          |
-| `-pxrange`    | `8`       | Pixel range of the distance gradient. Higher = more room for shader effects (outline, glow). `8` works well for the glyph density in this texture          |
-| `-scale`      | `1`       | 1:1 mapping — 1 SVG unit = 1 pixel. **Do not use `-autoframe`**: it rescales and adds padding, shifting UVs and breaking the shader's crop rects           |
-| `-translate`  | `0 0`     | No offset. msdfgen handles the SVG y-down → image y-down conversion correctly when reading from an SVG                                                      |
+| `-pxrange`    | `8`       | Pixel range of the distance gradient. Higher means more room for shader effects (outline, glow). `8` works well for the glyph density in this texture      |
+| `-scale`      | `1`       | 1:1 mapping, so 1 SVG unit = 1 pixel. **Do not use `-autoframe`**: it rescales and adds padding, shifting UVs and breaking the shader's crop rects         |
+| `-translate`  | `0 0`     | No offset. msdfgen handles the SVG y-down to image y-down conversion correctly when reading from an SVG                                                     |
 
 ### Verify the output
 
 Open the PNG and confirm:
 
 - The shapes are positioned where the SVG placed them.
-- There's **distinct red/green/blue fringing** around every edge — the MSDF signature.
+- There's **distinct red/green/blue fringing** around every edge, the MSDF signature.
 - The background is solid black where no shape exists.
 
-It won't look "clean" to the naked eye, and that's expected — the fragment shader reconstructs
+It won't look "clean" to the naked eye, and that's expected. The fragment shader reconstructs
 crisp edges by taking the **median** of the RGB channels.
 
 ## How the shader uses it

--- a/content/toolbox/msdfgen.mdx
+++ b/content/toolbox/msdfgen.mdx
@@ -42,20 +42,23 @@ See the snippet at the bottom for how the GPU reconstructs the edge.
 
 ## Installation
 
-The repo ships a CMake build and Vcpkg/Homebrew packages. The quickest paths:
+There's no Homebrew formula. The two supported paths are the Vcpkg package or a from-source
+CMake build.
 
-```bash title="macOS (Homebrew)"
-brew install msdfgen
+```bash title="Vcpkg"
+vcpkg install msdfgen
 ```
 
-```bash title="From source (CMake + Vcpkg)"
+```bash title="From source (CMake)"
 git clone https://github.com/Chlumsky/msdfgen
 cd msdfgen
 cmake -B build -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake
 cmake --build build
 ```
 
-Once installed you should have the `msdfgen` binary on your `PATH`. Verify with `msdfgen --help`.
+The from-source build pulls its dependencies (FreeType, and optionally the SVG/PNG libraries)
+through Vcpkg, so point `-DCMAKE_TOOLCHAIN_FILE` at your Vcpkg checkout. Once built you'll have the
+`msdfgen` binary; verify with `msdfgen --help`.
 
 ## The merge step (gotcha)
 

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -58,7 +58,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
       </figure>
     ),
     Image: ({ alt, ...props }: React.ComponentProps<typeof Image>) => (
-      <Image alt={alt} {...props} />
+      <Image alt={alt} unoptimized {...props} />
     ),
     ImageCols: ({
       className,


### PR DESCRIPTION
## Summary
Adds documentation for msdfgen, a CLI tool for generating multi-channel signed distance field (MSDF) textures from vector shapes. This page explains what MSDFs are, how to install msdfgen, and provides a practical workflow for generating and using MSDF textures in shaders.

## Changes
- Created `content/toolbox/msdfgen.mdx` with comprehensive documentation including:
  - Overview of MSDF technology and its benefits for rendering crisp text/icons at any scale
  - Installation instructions for macOS (Homebrew) and from source (CMake + Vcpkg)
  - Critical gotcha about merging multiple SVG paths into a single path element
  - Python script to automate the path merging process
  - Recommended generation workflow with detailed flag explanations
  - Verification checklist for generated MSDF textures
  - Example GLSL shader code showing how to reconstruct edges from the MSDF texture

## Notes
- The page includes placeholder image references (`src=""`) that should be populated with actual comparison images and MSDF texture examples
- Includes a warning callout about re-exporting SVGs from design tools requiring re-merging
- The shader example demonstrates the median-based edge reconstruction technique that makes MSDFs effective

https://claude.ai/code/session_012wJ6BP4rzqjvuHWZkzcbk7

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new toolbox page for msdfgen. The main changes are:

- Overview of MSDF texture generation and rendering use cases.
- Installation and SVG path-merging workflow.
- Texture generation command, verification checklist, and GLSL sampling example.
</details>

<h3>Confidence Score: 4/5</h3>

The new toolbox page can break static rendering through empty Next Image sources.

- The MDX page uses `Image` with `src=""`.
- The site passes MDX image props into Next Image during page rendering.
- Those placeholders need real URLs or removal before the page is published.

content/toolbox/msdfgen.mdx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/toolbox/msdfgen.mdx | Adds the msdfgen toolbox documentation page, but the placeholder image sources can break the rendered page. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/toolbox/msdfgen.mdx:26
**Empty Image Source Breaks Rendering**

This MDX `Image` is passed directly into Next Image during static rendering, and `src=""` is not a valid image URL. Building or visiting `/toolbox/msdfgen` can fail image validation or render a broken request for the page URL instead of the intended comparison asset.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add msdfgen toolbox post"](https://github.com/joyco-studio/hub/commit/4e5cff6d7c1c6a31501b49fb04fc1b34ad695799) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40164803)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))
- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->