### PR TITLE
Add log entry: Return, Don't Throw (Result pattern)

### DIFF
--- a/content/logs/17-return-dont-throw.mdx
+++ b/content/logs/17-return-dont-throw.mdx
@@ -1,0 +1,144 @@
+---
+title: 17 - Return, Don't Throw
+description: Return expected failures as one shared Result union built by two constructors, serialized to the wire in a single place, so throwing only ever means a bug.
+author: 'matiasperz'
+---
+
+Every API surface eventually grows two dialects for the same sentence. The route layer spells a refusal one way:
+
+```ts
+return Response.json({ error: 'unauthenticated' }, { status: 401 })
+```
+
+and the helpers underneath spell it another:
+
+```ts
+return { ok: false, status: 409, error: 'game_over' }
+```
+
+Same fact ("this didn't work, here's why, here's the status"), hand-written at every site, in whatever shape that site happened to reach for. We had both dialects, nineteen routes deep, before standardizing on one.
+
+## What it replaces: the anti-pattern
+
+The naive version scatters the response contract across every function that can fail:
+
+```ts
+// DON'T: every site invents the sentence again
+export async function POST(request: Request) {
+  const player = await getSessionPlayer()
+  if (!player) {
+    return Response.json({ error: 'unauthenticated' }, { status: 401 })
+  }
+  const result = await submitAttempt(player, group, gameSlug, score, opts)
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status })
+  }
+  return Response.json({ attempt: result.attempt, triesLeft: result.triesLeft })
+}
+```
+
+Call this the "hand-rolled wire". Three problems compound:
+
+1. **The wire shape is a convention, not a type.** Nothing stops one route from returning `{ message }` instead of `{ error }`, or forgetting the status. Consistency is enforced by diligence, which is to say it drifts.
+2. **Every helper mints its own union.** `SubmitResult`, `MintResult`, `RedeemResult`: each declared its `ok: false` branch by hand, each slightly different, and each route re-translated them to HTTP one field at a time.
+3. **Expected failure and genuine breakage share a channel.** If helpers throw for "no tries left", then `catch` blocks must sort player mistakes from real bugs, and sooner or later a bug gets caught, translated to a polite 400, and silenced.
+
+## The shape
+
+One discriminated union, two constructors, and nobody writes the literals again:
+
+```ts showLineNumbers
+export type Success<T> = { ok: true; data: T }
+
+export type Failure = {
+  ok: false
+  error: string // snake_case wire code
+  status: number
+}
+
+export type Result<T> = Success<T> | Failure
+
+export const success = <T>(data: T): Success<T> => ({ ok: true, data })
+
+export const error = (code: string, status = 400): Failure => ({
+  ok: false,
+  error: code,
+  status,
+})
+```
+
+This is [Phased State](/logs/16-phased-state-tagged-unions) applied to a function's outcome. A call has exactly two phases (it worked or it didn't) and each branch carries only what that phase means: `data` doesn't exist on a failure, `status` doesn't exist on a success. The bag-of-fields alternative (`{ data?, error?, status? }`) permits `data` and `error` set at once, and every reader has to defend against it. The union closes the gap: **you cannot touch `data` until you've looked at `ok`**, and the compiler is the one checking.
+
+Helpers with expected failure modes return it and **never throw for them**:
+
+```ts
+if (balance < SPIN_COST_POINTS) return error('insufficient_points', 403)
+// ...
+return success({ bonus, pointsBalance, mintsLeft })
+```
+
+Routes return the same union, and a wrapper at the boundary is the only code in the app that knows what the wire looks like:
+
+```ts showLineNumbers
+export function api<Args extends unknown[]>(
+  handler: (...args: Args) => Promise<Result<unknown> | Response>
+): (...args: Args) => Promise<Response> {
+  return async (...args) => {
+    let result: Result<unknown> | Response
+    try {
+      result = await handler(...args)
+    } catch (err) {
+      if (err instanceof ApiError) return err.toResponse()
+      throw err // real bugs keep bubbling to the 500
+    }
+    if (result instanceof Response) return result
+    return result.ok ? Response.json(result.data) : failureResponse(result)
+  }
+}
+```
+
+A handler now reads as what it decides, not how HTTP is spelled:
+
+```ts showLineNumbers
+export const POST = api(async (request: Request) => {
+  const player = await requirePlayer() // 401, thrown
+  const body = await readJsonBody<{ code?: unknown }>(request)
+  if (typeof body.code !== 'string') return error('code_required')
+  const { player: redeemed } = unwrap(await redeemCode(body.code))
+  return success({ player: pick(redeemed) })
+})
+```
+
+## What it buys you
+
+### 1. One vocabulary, one serializer
+
+`success()`/`error()` are the entire response API. The wire shape (`data` as the body, `{ error }` plus status) is decided in one function, so changing it (an envelope, an error `code`/`message` split, whatever) is a one-file edit. And because serialization strips the discriminant, `ok` never reaches the client; it exists for the type system, not the wire.
+
+### 2. Expected failure is a value; throwing means a bug
+
+"Insufficient points" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws past the wrapper is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error.
+
+### 3. The compiler makes every caller look
+
+`Result<T>` narrows: `if (!result.ok)` is the only door to `status`/`error`, and its absence is the only door to `data`. Callers can't optimistically grab the payload and hope. This is the same "illegal states are unrepresentable" payoff as any tagged union: the type system enforces the reading order the contract needs.
+
+### 4. The throwable twin covers the depth problem
+
+Some refusals are decided too deep to return through: inside a locked transaction that must roll back, or in a guard the handler didn't write. For those there's `ApiError(status, code)`: **the same Failure as a throwable**, nothing more. Guards throw it and the wrapper serializes it identically; a never-throw helper throws it inside its transaction (the throw _is_ the rollback) and catches it at its own boundary into `err.toFailure()`. And `unwrap(result)` bridges the other direction: failure becomes a thrown ApiError, success becomes the narrowed data:
+
+```ts
+const { attempt, triesLeft } = unwrap(
+  await submitAttempt(player, group, slug, score, opts)
+)
+```
+
+The union is the model; throwing is just transport. Both deliveries carry the same two fields and hit the same serializer, so there's still exactly one sentence.
+
+## When not to reach for it
+
+Don't wrap what can't fail: a function with no expected failure modes returns `T`, not `Result<T>`; reserving the union for real refusal keeps `ok` checks meaningful. Don't return what isn't expected: out-of-invariant conditions should throw and page you, not come back as a tidy 500-shaped value. And when a route genuinely needs the raw wire (our tick endpoint returns sweep data _with_ a 500 so cron monitoring flags it), it returns a `Response` and the wrapper passes it through; the escape hatch is explicit, not a second dialect.
+
+## The rule
+
+> Expected failures are values: every fallible boundary returns one shared `Result` union built only by `success()`/`error()`, serialized to the wire at a single point. Throwing is reserved for actual bugs, plus one throwable twin of the failure shape for refusals that must cross a transaction or guard boundary.

--- a/content/logs/17-return-dont-throw.mdx
+++ b/content/logs/17-return-dont-throw.mdx
@@ -13,7 +13,7 @@ return Response.json({ error: 'unauthenticated' }, { status: 401 })
 and the helpers underneath spell it another:
 
 ```ts
-return { ok: false, status: 409, error: 'game_over' }
+return { ok: false, status: 409, error: 'out_of_stock' }
 ```
 
 Same fact ("this didn't work, here's why, here's the status"), hand-written at every site, in whatever shape that site happened to reach for. We had both dialects, nineteen routes deep, before standardizing on one.
@@ -25,23 +25,24 @@ The naive version scatters the failure contract across every function that can f
 ```ts
 // DON'T: every site invents the sentence again
 export async function POST(request: Request) {
-  const player = await getSessionPlayer()
-  if (!player) {
+  const user = await getSessionUser()
+  if (!user) {
     return Response.json({ error: 'unauthenticated' }, { status: 401 })
   }
-  const result = await submitAttempt(player, group, gameSlug, score, opts)
+  const { items } = await request.json()
+  const result = await placeOrder(user, items)
   if (!result.ok) {
     return Response.json({ error: result.error }, { status: result.status })
   }
-  return Response.json({ attempt: result.attempt, triesLeft: result.triesLeft })
+  return Response.json({ order: result.order, remaining: result.remaining })
 }
 ```
 
 Call this the "hand-rolled wire". Three problems compound:
 
 1. **The failure shape is a convention, not a type.** Nothing stops one helper from returning `{ message }` instead of `{ error }`, or forgetting the status. Consistency is enforced by diligence, which is to say it drifts.
-2. **Every helper mints its own union.** `SubmitResult`, `MintResult`, `RedeemResult`: each declared its `ok: false` branch by hand, each slightly different, and each route re-translated them to HTTP one field at a time.
-3. **Expected failure and genuine breakage share a channel.** If helpers throw for "no tries left", then `catch` blocks must sort player mistakes from real bugs, and sooner or later a bug gets caught, translated to a polite 400, and silenced.
+2. **Every helper mints its own union.** `PlaceOrderResult`, `ApplyCouponResult`, `RefundResult`: each declared its `ok: false` branch by hand, each slightly different, and each route re-translated them to HTTP one field at a time.
+3. **Expected failure and genuine breakage share a channel.** If helpers throw for "out of stock", then `catch` blocks must sort user mistakes from real bugs, and sooner or later a bug gets caught, translated to a polite 400, and silenced.
 
 ## The shape
 
@@ -72,15 +73,15 @@ This is [Phased State](/logs/16-phased-state-tagged-unions) applied to a functio
 Helpers with expected failure modes return it and **never throw for them**:
 
 ```ts
-if (balance < SPIN_COST_POINTS) return error('insufficient_points', 403)
+if (stock < item.qty) return error('out_of_stock', 409)
 // ...
-return success({ bonus, pointsBalance, mintsLeft })
+return success({ order, remaining })
 ```
 
 The caller narrows once and both branches fall out fully typed:
 
 ```ts
-const result = await spinWheel(player)
+const result = await applyCoupon(user, code)
 if (!result.ok) {
   return Response.json({ error: result.error }, { status: result.status })
 }
@@ -91,11 +92,11 @@ return Response.json(result.data)
 
 ### 1. One vocabulary instead of N conventions
 
-`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`SubmitResult`, `MintResult`, …) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
+`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`PlaceOrderResult`, `ApplyCouponResult`, …) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
 
 ### 2. Expected failure is a value; throwing means a bug
 
-"Insufficient points" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error by a well-meaning `catch`.
+"Out of stock" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error by a well-meaning `catch`.
 
 ### 3. The compiler makes every caller look
 
@@ -107,7 +108,7 @@ Because every layer speaks the same union, a helper that calls another helper ca
 
 ## When not to reach for it
 
-Don't wrap what can't fail: a function with no expected failure modes returns `T`, not `Result<T>`; reserving the union for real refusal keeps `ok` checks meaningful. And don't return what isn't expected: out-of-invariant conditions ("this row must exist by now") should throw and page you, not come back as a tidy 500-shaped value. The line is expectation, not severity. A player being out of tries is expected; a corrupt game state is not.
+Don't wrap what can't fail: a function with no expected failure modes returns `T`, not `Result<T>`; reserving the union for real refusal keeps `ok` checks meaningful. And don't return what isn't expected: out-of-invariant conditions ("this row must exist by now") should throw and page you, not come back as a tidy 500-shaped value. The line is expectation, not severity. A sold-out item is expected; an order with a negative total is not.
 
 ## The rule
 

--- a/content/logs/17-return-dont-throw.mdx
+++ b/content/logs/17-return-dont-throw.mdx
@@ -1,6 +1,6 @@
 ---
 title: 17 - Return, Don't Throw
-description: Return expected failures as one shared Result union built by two constructors, serialized to the wire in a single place, so throwing only ever means a bug.
+description: Return expected failures as one shared Result union built by success() and error(), so callers must look before touching data and throwing only ever means a bug.
 author: 'matiasperz'
 ---
 
@@ -20,7 +20,7 @@ Same fact ("this didn't work, here's why, here's the status"), hand-written at e
 
 ## What it replaces: the anti-pattern
 
-The naive version scatters the response contract across every function that can fail:
+The naive version scatters the failure contract across every function that can fail:
 
 ```ts
 // DON'T: every site invents the sentence again
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
 
 Call this the "hand-rolled wire". Three problems compound:
 
-1. **The wire shape is a convention, not a type.** Nothing stops one route from returning `{ message }` instead of `{ error }`, or forgetting the status. Consistency is enforced by diligence, which is to say it drifts.
+1. **The failure shape is a convention, not a type.** Nothing stops one helper from returning `{ message }` instead of `{ error }`, or forgetting the status. Consistency is enforced by diligence, which is to say it drifts.
 2. **Every helper mints its own union.** `SubmitResult`, `MintResult`, `RedeemResult`: each declared its `ok: false` branch by hand, each slightly different, and each route re-translated them to HTTP one field at a time.
 3. **Expected failure and genuine breakage share a channel.** If helpers throw for "no tries left", then `catch` blocks must sort player mistakes from real bugs, and sooner or later a bug gets caught, translated to a polite 400, and silenced.
 
@@ -77,68 +77,38 @@ if (balance < SPIN_COST_POINTS) return error('insufficient_points', 403)
 return success({ bonus, pointsBalance, mintsLeft })
 ```
 
-Routes return the same union, and a wrapper at the boundary is the only code in the app that knows what the wire looks like:
+The caller narrows once and both branches fall out fully typed:
 
-```ts showLineNumbers
-export function api<Args extends unknown[]>(
-  handler: (...args: Args) => Promise<Result<unknown> | Response>
-): (...args: Args) => Promise<Response> {
-  return async (...args) => {
-    let result: Result<unknown> | Response
-    try {
-      result = await handler(...args)
-    } catch (err) {
-      if (err instanceof ApiError) return err.toResponse()
-      throw err // real bugs keep bubbling to the 500
-    }
-    if (result instanceof Response) return result
-    return result.ok ? Response.json(result.data) : failureResponse(result)
-  }
+```ts
+const result = await spinWheel(player)
+if (!result.ok) {
+  return Response.json({ error: result.error }, { status: result.status })
 }
-```
-
-A handler now reads as what it decides, not how HTTP is spelled:
-
-```ts showLineNumbers
-export const POST = api(async (request: Request) => {
-  const player = await requirePlayer() // 401, thrown
-  const body = await readJsonBody<{ code?: unknown }>(request)
-  if (typeof body.code !== 'string') return error('code_required')
-  const { player: redeemed } = unwrap(await redeemCode(body.code))
-  return success({ player: pick(redeemed) })
-})
+return Response.json(result.data)
 ```
 
 ## What it buys you
 
-### 1. One vocabulary, one serializer
+### 1. One vocabulary instead of N conventions
 
-`success()`/`error()` are the entire response API. The wire shape (`data` as the body, `{ error }` plus status) is decided in one function, so changing it (an envelope, an error `code`/`message` split, whatever) is a one-file edit. And because serialization strips the discriminant, `ok` never reaches the client; it exists for the type system, not the wire.
+`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`SubmitResult`, `MintResult`, ...) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
 
 ### 2. Expected failure is a value; throwing means a bug
 
-"Insufficient points" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws past the wrapper is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error.
+"Insufficient points" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error by a well-meaning `catch`.
 
 ### 3. The compiler makes every caller look
 
 `Result<T>` narrows: `if (!result.ok)` is the only door to `status`/`error`, and its absence is the only door to `data`. Callers can't optimistically grab the payload and hope. This is the same "illegal states are unrepresentable" payoff as any tagged union: the type system enforces the reading order the contract needs.
 
-### 4. The throwable twin covers the depth problem
+### 4. Failures compose across layers
 
-Some refusals are decided too deep to return through: inside a locked transaction that must roll back, or in a guard the handler didn't write. For those there's `ApiError(status, code)`: **the same Failure as a throwable**, nothing more. Guards throw it and the wrapper serializes it identically; a never-throw helper throws it inside its transaction (the throw _is_ the rollback) and catches it at its own boundary into `err.toFailure()`. And `unwrap(result)` bridges the other direction: failure becomes a thrown ApiError, success becomes the narrowed data:
-
-```ts
-const { attempt, triesLeft } = unwrap(
-  await submitAttempt(player, group, slug, score, opts)
-)
-```
-
-The union is the model; throwing is just transport. Both deliveries carry the same two fields and hit the same serializer, so there's still exactly one sentence.
+Because every layer speaks the same union, a helper that calls another helper can forward a refusal untouched: `if (!inner.ok) return inner`. No re-wrapping, no lossy translation from one ad-hoc shape to another; the original code and status travel from the depth where the decision was made to the boundary that reports it.
 
 ## When not to reach for it
 
-Don't wrap what can't fail: a function with no expected failure modes returns `T`, not `Result<T>`; reserving the union for real refusal keeps `ok` checks meaningful. Don't return what isn't expected: out-of-invariant conditions should throw and page you, not come back as a tidy 500-shaped value. And when a route genuinely needs the raw wire (our tick endpoint returns sweep data _with_ a 500 so cron monitoring flags it), it returns a `Response` and the wrapper passes it through; the escape hatch is explicit, not a second dialect.
+Don't wrap what can't fail: a function with no expected failure modes returns `T`, not `Result<T>`; reserving the union for real refusal keeps `ok` checks meaningful. And don't return what isn't expected: out-of-invariant conditions ("this row must exist by now") should throw and page you, not come back as a tidy 500-shaped value. The line is expectation, not severity. A player being out of tries is expected; a corrupt game state is not.
 
 ## The rule
 
-> Expected failures are values: every fallible boundary returns one shared `Result` union built only by `success()`/`error()`, serialized to the wire at a single point. Throwing is reserved for actual bugs, plus one throwable twin of the failure shape for refusals that must cross a transaction or guard boundary.
+> Expected failures are values: every fallible helper returns one shared `Result` union built only by `success()`/`error()`, callers narrow on `ok` before touching either branch, and throwing is reserved for actual bugs.

--- a/content/logs/17-return-dont-throw.mdx
+++ b/content/logs/17-return-dont-throw.mdx
@@ -91,7 +91,7 @@ return Response.json(result.data)
 
 ### 1. One vocabulary instead of N conventions
 
-`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`SubmitResult`, `MintResult`, ...) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
+`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`SubmitResult`, `MintResult`, …) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
 
 ### 2. Expected failure is a value; throwing means a bug
 

--- a/content/logs/17-return-dont-throw.mdx
+++ b/content/logs/17-return-dont-throw.mdx
@@ -92,19 +92,46 @@ return Response.json(result.data)
 
 ### 1. One vocabulary instead of N conventions
 
-`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`PlaceOrderResult`, `ApplyCouponResult`, …) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
+`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`PlaceOrderResult`, `ApplyCouponResult`, …) collapse into one `Result<T>` that only varies in `T`:
+
+```ts
+placeOrder(user, items) // Result<{ order: Order; remaining: number }>
+applyCoupon(user, code) // Result<{ discount: number }>
+refundOrder(orderId) // Result<{ refundId: string }>
+```
+
+Routes stop re-translating bespoke shapes field by field. The `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. That sameness is also what would let a boundary wrapper absorb it one day, but that's its own log; the union earns its keep before any wrapper exists.
 
 ### 2. Expected failure is a value; throwing means a bug
 
-"Out of stock" is not exceptional; it's a Tuesday. When helpers return it, control flow reads top-to-bottom with no invisible exits, and the exception channel regains its meaning: anything that actually throws is a genuine defect and surfaces as a loud 500 in the logs, never accidentally laundered into a polite client error by a well-meaning `catch`.
+"Out of stock" is not exceptional; it's a Tuesday. When a helper returns it, control flow reads top-to-bottom with no invisible exits.
+
+The quieter win is what happens to the exception channel: it gets its meaning back. Anything that still throws is a genuine defect, and it surfaces as a loud 500 in the logs instead of being laundered into a polite client error by a well-meaning `catch`.
 
 ### 3. The compiler makes every caller look
 
-`Result<T>` narrows: `if (!result.ok)` is the only door to `status`/`error`, and its absence is the only door to `data`. Callers can't optimistically grab the payload and hope. This is the same "illegal states are unrepresentable" payoff as any tagged union: the type system enforces the reading order the contract needs.
+`Result<T>` narrows, and narrowing is the only way in:
+
+```ts
+result.data // type error: might be a Failure
+if (!result.ok) {
+  result.status // fine: narrowed to Failure
+  result.data // type error: failures carry no data
+}
+```
+
+Callers can't optimistically grab the payload and hope. It's the same "illegal states are unrepresentable" payoff as any tagged union: the type system enforces the reading order the contract needs.
 
 ### 4. Failures compose across layers
 
-Because every layer speaks the same union, a helper that calls another helper can forward a refusal untouched: `if (!inner.ok) return inner`. No re-wrapping, no lossy translation from one ad-hoc shape to another; the original code and status travel from the depth where the decision was made to the boundary that reports it.
+Every layer speaks the same union, so a helper that calls another helper forwards a refusal untouched:
+
+```ts
+const reserved = await reserveStock(items)
+if (!reserved.ok) return reserved // code and status travel as-is
+```
+
+No re-wrapping, no lossy translation between ad-hoc shapes. The refusal keeps its original code and status from the depth where it was decided all the way to the boundary that reports it.
 
 ## When not to reach for it
 


### PR DESCRIPTION
Adds a new log entry documenting the Result union pattern for handling expected failures in API helpers and route handlers.

## Summary

This entry explains how to standardize failure handling across an API surface using a discriminated union type (`Result<T>`) with `success()` and `error()` constructors, replacing ad-hoc failure shapes and exception-based control flow.

## Key Changes

- **New content file**: `content/logs/17-return-dont-throw.mdx`
  - Explains the anti-pattern of hand-rolled failure contracts scattered across helpers
  - Documents the `Result<T>` union shape with `Success<T>` and `Failure` branches
  - Shows how callers narrow on `ok` to safely access typed data or error details
  - Covers four benefits: unified vocabulary, expected failures as values, compiler enforcement, and composable failures across layers
  - Includes guidance on when not to use the pattern (functions that can't fail, out-of-invariant conditions)

## Implementation Details

The entry uses code examples to contrast the anti-pattern (multiple failure shapes, hand-written translations at every route) with the solution (single `Result` union, mechanical narrowing). It positions this as an application of the Phased State/tagged union pattern to function outcomes, emphasizing that the type system prevents accessing data before checking `ok`, and that throwing is reserved for genuine bugs rather than expected failures.

Note: This file will need to be added to `content/logs/meta.json` in the `pages` array (in alphabetical order) to appear in the sidebar.

https://claude.ai/code/session_018chu1SnXzqmzjAi4pHTiZA

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new log entry about returning expected failures as `Result` values. The main changes are:

- New `content/logs/17-return-dont-throw.mdx` page.
- Frontmatter for title, description, and author.
- TypeScript examples for `Result<T>`, `success()`, and `error()`.
- Guidance on when to return failures and when to throw.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small typography cleanup.

- The new log page follows the existing filename and frontmatter pattern.
- The internal links point to existing log pages.
- The remaining issue is a rendered prose convention mismatch.

content/logs/17-return-dont-throw.mdx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/logs/17-return-dont-throw.mdx | Adds a standard MDX log page that should be discovered with the existing logs; one prose typography cleanup remains. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
content/logs/17-return-dont-throw.mdx:94
**Prose Ellipsis Uses Periods**

This parenthetical list uses `...` in rendered prose, but the typography guideline requires the single `…` character outside code. The published log entry will show typography that does not match the site convention.

```suggestion
`success()`/`error()` are the only way a failure gets built, so every fallible helper speaks the same sentence. The per-helper unions (`SubmitResult`, `MintResult`, …) collapse into `Result<T>` with different `T`s, and routes stop re-translating bespoke shapes field by field: the `!result.ok` branch is identical everywhere, mechanical enough to copy without thinking. It's also mechanical enough to centralize into a boundary wrapper eventually, but that's its own log; the union earns its keep before any wrapper exists.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refocus log 17 on the Result union itsel..."](https://github.com/joyco-studio/hub/commit/daa2a3195c7e1233250b5f27237aee06756fba37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43723458)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))
- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->