### PR TITLE
Enforce log numbering in CI

### DIFF
--- a/.github/workflows/check-logs.yml
+++ b/.github/workflows/check-logs.yml
@@ -1,0 +1,26 @@
+name: Check Logs
+
+on:
+  pull_request:
+    paths:
+      - 'content/logs/**'
+      - 'scripts/check-log-numbers.mjs'
+      - '.github/workflows/check-logs.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'content/logs/**'
+      - 'scripts/check-log-numbers.mjs'
+      - '.github/workflows/check-logs.yml'
+
+jobs:
+  check-log-numbers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Check log numbering
+        run: node scripts/check-log-numbers.mjs

--- a/content/logs/13-working-with-reduced-motion.mdx
+++ b/content/logs/13-working-with-reduced-motion.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reduced motion and GSAP: The Invisible Collision Layer"
+title: "13 - Reduced motion and GSAP: The Invisible Collision Layer"
 author: 'justkahdri'
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "postinstall": "fumadocs-mdx",
     "build:registry": "shadcn build",
     "lint": "eslint",
+    "check:logs": "node scripts/check-log-numbers.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"

--- a/scripts/check-log-numbers.mjs
+++ b/scripts/check-log-numbers.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Enforces the numbering convention for log entries in content/logs/.
+//
+// Every log entry must:
+//   1. Have a filename that starts with a two-plus-digit number prefix: `NN-slug.mdx`
+//   2. Carry that same number at the start of its `title` frontmatter: `title: NN - …`
+//   3. Own a unique number — no two entries may share a prefix.
+//
+// `index.mdx` is the section landing page, not an entry, so it is exempt.
+// Run locally with `node scripts/check-log-numbers.mjs`; CI runs the same command.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const LOGS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'content',
+  'logs'
+)
+
+const IGNORED_FILES = new Set(['index.mdx'])
+const FILENAME_PREFIX = /^(\d{2,})-/
+const FRONTMATTER = /^---\r?\n(.*?)\r?\n---/s
+const TITLE_NUMBER = /^title:\s*['"]?(\d{2,})\s*-\s/m
+
+/**
+ * Pull the number out of the `title:` line, but only from the leading `---`
+ * frontmatter block — never from body prose or a code fence that happens to
+ * contain a `title:` line.
+ */
+function readTitleNumber(contents) {
+  const frontmatter = contents.match(FRONTMATTER)
+  if (!frontmatter) return null
+  const match = frontmatter[1].match(TITLE_NUMBER)
+  return match ? match[1] : null
+}
+
+const entries = readdirSync(LOGS_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && !IGNORED_FILES.has(entry.name))
+  .map((entry) => entry.name)
+
+const errors = []
+const numberToFiles = new Map()
+
+for (const name of entries) {
+  const filenameMatch = name.match(FILENAME_PREFIX)
+
+  if (!filenameMatch) {
+    errors.push(
+      `${name}: filename must start with a number prefix, e.g. "18-${name}".`
+    )
+    continue
+  }
+
+  const fileNumber = filenameMatch[1]
+
+  if (!numberToFiles.has(fileNumber)) numberToFiles.set(fileNumber, [])
+  numberToFiles.get(fileNumber).push(name)
+
+  if (!name.endsWith('.mdx')) {
+    errors.push(
+      `${name}: log entries must use the .mdx extension (got "${name.replace(/^.*(\.[^.]+)$/, '$1')}").`
+    )
+    continue
+  }
+
+  const contents = readFileSync(join(LOGS_DIR, name), 'utf8')
+  const titleNumber = readTitleNumber(contents)
+
+  if (titleNumber === null) {
+    errors.push(
+      `${name}: title frontmatter must start with its number, e.g. "title: ${fileNumber} - …".`
+    )
+  } else if (titleNumber !== fileNumber) {
+    errors.push(
+      `${name}: title number (${titleNumber}) does not match filename number (${fileNumber}).`
+    )
+  }
+}
+
+for (const [number, files] of numberToFiles) {
+  if (files.length > 1) {
+    errors.push(
+      `Duplicate log number ${number} used by: ${files.join(', ')}.`
+    )
+  }
+}
+
+if (errors.length > 0) {
+  console.error('✗ Log numbering check failed:\n')
+  for (const error of errors) console.error(`  • ${error}`)
+  console.error(
+    `\n${errors.length} problem(s) found in content/logs/. Fix them before merging.`
+  )
+  process.exit(1)
+}
+
+console.log(`✓ All ${entries.length} log entries are correctly numbered.`)


### PR DESCRIPTION
## What

**CI enforcement for log numbering.** Adds `scripts/check-log-numbers.mjs` (also wired as `pnpm check:logs`) and a `check-logs.yml` workflow that fails a PR when any `content/logs` entry:

- lacks a numeric filename prefix (`NN-slug.mdx`),
- isn't a `.mdx` file (any non-`.mdx` file in the directory now fails, not just `.md`),
- is missing the number at the start of its `title` frontmatter, or its title number disagrees with the filename (read only from the leading frontmatter block, so a `title:` line in body prose or a code fence no longer satisfies it),
- shares a number with another entry.

**Fixed one pre-existing violation.** `13-working-with-reduced-motion.mdx` was missing the `13 - ` prefix in its title, now corrected. All tracked entries pass.

## Verification

`node scripts/check-log-numbers.mjs` -> all log entries are correctly numbered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds CI enforcement for numbered log entries. The main changes are:

- A new script validates log filenames, title numbers, file extensions, and duplicate numbers.
- A new workflow runs the log checker for log-related changes.
- `package.json` exposes the checker as `check:logs`.
- The reduced-motion log title now matches its filename number.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-log-numbers.mjs | Adds the log-numbering checker for filenames, title frontmatter, extensions, and duplicate numbers. |
| .github/workflows/check-logs.yml | Adds a workflow that runs the checker when log content or checker files change. |
| package.json | Adds the `check:logs` script. |
| content/logs/13-working-with-reduced-motion.mdx | Updates the title to include the matching log number. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Enforce log numbering in CI"](https://github.com/joyco-studio/hub/commit/60fcf7194e0976da8a4a934e0129e0994be0787f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43925413)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->