### PR TITLE
fix(logs): AA-legible trazo diagram labels + keep renderer server-only

### DIFF
--- a/app/(registry)/[[...slug]]/page.tsx
+++ b/app/(registry)/[[...slug]]/page.tsx
@@ -203,9 +203,12 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
             )}
           >
             <MDX
-              components={getMDXComponents({
-                a: createRelativeLink(source, page),
-              })}
+              components={getMDXComponents(
+                {
+                  a: createRelativeLink(source, page),
+                },
+                { logNumber }
+              )}
             />
             {libraryReadme && <MDXContent content={libraryReadme.cleaned} />}
           </div>

--- a/app/styles/theming.css
+++ b/app/styles/theming.css
@@ -39,19 +39,20 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
-  /* trazo diagram label colors — text drawn on each saturated node fill.
-     Picked per fill for AA contrast against the chart/role colors above. */
-  --trazo-primary-foreground: oklch(1 0 0);
-  --trazo-success-foreground: oklch(0.145 0 0);
+  /* trazo diagram label text — one AA-checked color per chart fill. Trazo resolves
+     both the lane slots (lane-2..6 → chart-1..5) and the chart-backed roles
+     (success → chart-2, info → chart-3, warning → chart-4) to these through its
+     token fallback, so every saturated node reads legibly. Contrast picked per fill
+     against oklch(0.145) vs white; see chart-N lightness above. */
+  --chart-1-foreground: oklch(1 0 0);
+  --chart-2-foreground: oklch(0.145 0 0);
+  --chart-3-foreground: oklch(1 0 0);
+  --chart-4-foreground: oklch(0.145 0 0);
+  --chart-5-foreground: oklch(1 0 0);
+
+  /* error fills use --destructive, primary/lane-1 use --primary-foreground —
+     neither is a chart color, so pair them explicitly. */
   --trazo-error-foreground: oklch(1 0 0);
-  --trazo-warning-foreground: oklch(0.145 0 0);
-  --trazo-streamed-foreground: oklch(1 0 0);
-  --trazo-lane-1-foreground: oklch(1 0 0);
-  --trazo-lane-2-foreground: oklch(1 0 0);
-  --trazo-lane-3-foreground: oklch(0.145 0 0);
-  --trazo-lane-4-foreground: oklch(1 0 0);
-  --trazo-lane-5-foreground: oklch(0.145 0 0);
-  --trazo-lane-6-foreground: oklch(1 0 0);
 }
 
 .dark {
@@ -85,17 +86,12 @@
   --chart-4: oklch(0.78 0.10 253);
   --chart-5: oklch(0.63 0.08 273);
 
-  --trazo-primary-foreground: oklch(1 0 0);
-  --trazo-success-foreground: oklch(0.145 0 0);
+  --chart-1-foreground: oklch(0.145 0 0);
+  --chart-2-foreground: oklch(0.145 0 0);
+  --chart-3-foreground: oklch(1 0 0);
+  --chart-4-foreground: oklch(0.145 0 0);
+  --chart-5-foreground: oklch(0.145 0 0);
   --trazo-error-foreground: oklch(0.145 0 0);
-  --trazo-warning-foreground: oklch(0.145 0 0);
-  --trazo-streamed-foreground: oklch(1 0 0);
-  --trazo-lane-1-foreground: oklch(1 0 0);
-  --trazo-lane-2-foreground: oklch(0.145 0 0);
-  --trazo-lane-3-foreground: oklch(0.145 0 0);
-  --trazo-lane-4-foreground: oklch(1 0 0);
-  --trazo-lane-5-foreground: oklch(0.145 0 0);
-  --trazo-lane-6-foreground: oklch(0.145 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -139,17 +135,12 @@
   --chart-4: oklch(0.70 0.12 253);
   --chart-5: oklch(0.55 0.10 273);
 
-  --trazo-primary-foreground: oklch(0.145 0 0);
-  --trazo-success-foreground: oklch(0.145 0 0);
+  --chart-1-foreground: oklch(1 0 0);
+  --chart-2-foreground: oklch(0.145 0 0);
+  --chart-3-foreground: oklch(1 0 0);
+  --chart-4-foreground: oklch(0.145 0 0);
+  --chart-5-foreground: oklch(1 0 0);
   --trazo-error-foreground: oklch(1 0 0);
-  --trazo-warning-foreground: oklch(0.145 0 0);
-  --trazo-streamed-foreground: oklch(1 0 0);
-  --trazo-lane-1-foreground: oklch(0.145 0 0);
-  --trazo-lane-2-foreground: oklch(1 0 0);
-  --trazo-lane-3-foreground: oklch(0.145 0 0);
-  --trazo-lane-4-foreground: oklch(1 0 0);
-  --trazo-lane-5-foreground: oklch(0.145 0 0);
-  --trazo-lane-6-foreground: oklch(1 0 0);
   --sidebar: oklch(0.955 0.025 250);
   --sidebar-foreground: oklch(0.145 0.025 250);
   --sidebar-primary: oklch(0.65 0.2 45);
@@ -193,17 +184,12 @@
   --chart-5: oklch(0.75 0.22 140);
 
   /* terminal fills are bright greens — dark text reads on every one. */
-  --trazo-primary-foreground: oklch(0.145 0 0);
-  --trazo-success-foreground: oklch(0.145 0 0);
+  --chart-1-foreground: oklch(0.145 0 0);
+  --chart-2-foreground: oklch(0.145 0 0);
+  --chart-3-foreground: oklch(0.145 0 0);
+  --chart-4-foreground: oklch(0.145 0 0);
+  --chart-5-foreground: oklch(0.145 0 0);
   --trazo-error-foreground: oklch(0.145 0 0);
-  --trazo-warning-foreground: oklch(0.145 0 0);
-  --trazo-streamed-foreground: oklch(0.145 0 0);
-  --trazo-lane-1-foreground: oklch(0.145 0 0);
-  --trazo-lane-2-foreground: oklch(0.145 0 0);
-  --trazo-lane-3-foreground: oklch(0.145 0 0);
-  --trazo-lane-4-foreground: oklch(0.145 0 0);
-  --trazo-lane-5-foreground: oklch(0.145 0 0);
-  --trazo-lane-6-foreground: oklch(0.145 0 0);
   --sidebar: oklch(0.1 0.012 140);
   --sidebar-foreground: oklch(0.85 0.18 145);
   --sidebar-primary: oklch(0.7 0.2 145);

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -7,9 +7,29 @@ import {
   parseSequence,
   parseBlock,
   parseGit,
+  themeFlowOptions,
+  themeGitOptions,
+  joycoTheme,
   type PositionedGraph,
+  type TrazoTheme,
 } from '@joycostudio/trazo'
 import { Graph } from '@joycostudio/trazo/react'
+import { Badge } from '@/components/ui/badge'
+
+// The full-width frame draws its own textured canvas + border, so the graph's
+// own canvas backdrop is turned off to avoid a doubled texture rectangle.
+//
+// With `background: 'none'` trazo skips its chip-lift auto-follow — the step that
+// normally keeps the node-box stroke (`--trazo-bg`) equal to the canvas it paints.
+// Left unset, that stroke falls back to `--background`, which does NOT match this
+// frame's `bg-card` surface, so the boxes would show a mismatched outline ring.
+// Pin `--trazo-bg` to the frame's own color (`--card`) so the strokes read as the
+// same surface the boxes sit on. Keep this in sync with the frame's `bg-card`.
+const graphTheme: TrazoTheme = {
+  ...joycoTheme,
+  background: 'none',
+  tokens: { ...joycoTheme.tokens, bg: 'var(--card)' },
+}
 
 type DiagramLang = 'flow' | 'sequence' | 'block' | 'git'
 
@@ -43,12 +63,12 @@ function layoutFor(lang: DiagramLang, source: string): PositionedGraph {
     case 'git': {
       const { graph, error } = parseGit(source)
       if (error) throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
-      return layoutGit(graph)
+      return layoutGit(graph, themeGitOptions(joycoTheme))
     }
     default: {
       const { graph, error } = parseFlow(source)
       if (error) throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
-      return layoutFlow(graph)
+      return layoutFlow(graph, themeFlowOptions(joycoTheme))
     }
   }
 }
@@ -56,18 +76,58 @@ function layoutFor(lang: DiagramLang, source: string): PositionedGraph {
 export function Diagram({
   children,
   title,
+  index,
+  articleNumber,
   className,
 }: {
   children: string
   title?: string
+  index?: number
+  articleNumber?: string
   className?: string
 }) {
   const source = String(children).trim()
   const graph = layoutFor(detectLang(source), source)
 
+  // The corner tag reads `N{article}-{illustration}` (e.g. N07-01): the log's
+  // number, injected per-page, paired with this diagram's order in the article.
+  const tag =
+    articleNumber && index != null
+      ? `N${articleNumber}-${String(index).padStart(2, '0')}`
+      : undefined
+
   return (
-    <div className="my-6 flex justify-center [&_svg]:max-w-full">
-      <Graph graph={graph} title={title} className={className} />
-    </div>
+    <figure className="not-prose border-border bg-card relative my-8 w-full overflow-hidden border">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'repeating-linear-gradient(45deg, color-mix(in oklab, var(--foreground) 4%, transparent) 0 1px, transparent 1px 8px)',
+        }}
+      />
+      {title && (
+        <Badge
+          asChild
+          variant="accent"
+          size="sm"
+          className="absolute top-2 left-2 z-10 h-6 max-w-[70%] font-normal"
+        >
+          <figcaption className="truncate">{title}</figcaption>
+        </Badge>
+      )}
+      {tag && (
+        <Badge
+          variant="accent"
+          size="sm"
+          className="absolute top-2 right-2 z-10 h-6 font-normal tabular-nums"
+        >
+          {tag}
+        </Badge>
+      )}
+      <div className="relative flex justify-center px-6 py-12 [&_svg]:max-w-full">
+        <Graph graph={graph} title={title} className={className} theme={graphTheme} />
+      </div>
+    </figure>
   )
 }

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -1,3 +1,4 @@
+import 'server-only'
 import {
   layoutFlow,
   layoutSequence,
@@ -48,7 +49,7 @@ function detectLang(source: string): DiagramLang {
   return 'flow'
 }
 
-function layoutFor(lang: DiagramLang, source: string): PositionedGraph {
+function layoutFor(lang: DiagramLang, source: string, theme: TrazoTheme): PositionedGraph {
   switch (lang) {
     case 'sequence': {
       const { graph, error } = parseSequence(source)
@@ -63,12 +64,12 @@ function layoutFor(lang: DiagramLang, source: string): PositionedGraph {
     case 'git': {
       const { graph, error } = parseGit(source)
       if (error) throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
-      return layoutGit(graph, themeGitOptions(joycoTheme))
+      return layoutGit(graph, themeGitOptions(theme))
     }
     default: {
       const { graph, error } = parseFlow(source)
       if (error) throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
-      return layoutFlow(graph, themeFlowOptions(joycoTheme))
+      return layoutFlow(graph, themeFlowOptions(theme))
     }
   }
 }
@@ -87,7 +88,7 @@ export function Diagram({
   className?: string
 }) {
   const source = String(children).trim()
-  const graph = layoutFor(detectLang(source), source)
+  const graph = layoutFor(detectLang(source), source, graphTheme)
 
   // The corner tag reads `N{article}-{illustration}` (e.g. N07-01): the log's
   // number, injected per-page, paired with this diagram's order in the article.
@@ -98,14 +99,9 @@ export function Diagram({
 
   return (
     <figure className="not-prose border-border bg-card relative my-8 w-full overflow-hidden border">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0"
-        style={{
-          backgroundImage:
-            'repeating-linear-gradient(45deg, color-mix(in oklab, var(--foreground) 4%, transparent) 0 1px, transparent 1px 8px)',
-        }}
-      />
+      {/* figcaption must be the first or last child of <figure> per the HTML content
+          model, so the caption Badge leads; the remaining overlays are absolutely
+          positioned, so DOM order doesn't affect the visual stacking. */}
       {title && (
         <Badge
           asChild
@@ -116,6 +112,14 @@ export function Diagram({
           <figcaption className="truncate">{title}</figcaption>
         </Badge>
       )}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'repeating-linear-gradient(45deg, color-mix(in oklab, var(--foreground) 4%, transparent) 0 1px, transparent 1px 8px)',
+        }}
+      />
       {tag && (
         <Badge
           variant="accent"

--- a/content/logs/07-nextjs-promises-ppr.mdx
+++ b/content/logs/07-nextjs-promises-ppr.mdx
@@ -30,7 +30,7 @@ export default async function RootLayout({ children }) {
 
 **The problem**: you're `await`-ing at the root. Nothing renders until those fetches resolve. Your entire page is held hostage by the slowest provider.
 
-<Diagram title="Blocking await chain">{`flow TD
+<Diagram index={1} title="Blocking await chain">{`flow TD
 A(["Request arrives"]):primary
 B["await getCart()<br/>200ms"]:error
 C["await getFlags()<br/>150ms"]:error
@@ -69,12 +69,12 @@ export default function RootLayout({ children }) {
 
 The layout returns immediately. The promises are in-flight. Client components resolve them when they're ready, wrapped in `<Suspense>`.
 
-<Diagram title="Forward promises, render shell immediately">{`flow TD
+<Diagram index={2} title="Forward promises, render shell immediately">{`flow TD
 A(["Request arrives"]):primary
 B["getCart() started"]:success
 C["getFlags() started"]:success
 D["Render HTML shell immediately<br/>(Suspense fallbacks)"]:primary
-E["Stream resolved data<br/>as promises settle"]:streamed
+E["Stream resolved data<br/>as promises settle"]:info
 A --- B
 A --- C
 A --- D
@@ -339,7 +339,7 @@ With **Partial Prerendering** (PPR), enabled via `cacheComponents: true` in Next
 1. A **static shell** prerendered at build time (the HTML around your Suspense fallbacks)
 2. **Dynamic holes** that stream at request time (the actual content inside those boundaries)
 
-<Diagram title="The static shell: built at build time, served from CDN">{`flow TD
+<Diagram index={3} title="The static shell: built at build time, served from CDN">{`flow TD
 shell(["Static Shell — built at build time, served from CDN"])
 nav["<nav> Store </nav>"]:primary
 skeleton1["CartTotal skeleton"]:warning
@@ -355,13 +355,13 @@ main --- fallback`}</Diagram>
 
 When a request comes in, the static shell is **instantly** served. Then the dynamic parts stream in:
 
-<Diagram title="Shell served instantly, dynamic parts stream in">{`flow TD
+<Diagram index={4} title="Shell served instantly, dynamic parts stream in">{`flow TD
 A(["Static shell served<br/>0ms"]):primary
 S["UI renders with<br/>Suspense fallbacks instantly"]:warning
 B["getFlags resolves<br/>80ms"]:success
 C["getCart resolves<br/>120ms"]:success
-D["CheckoutButton renders<br/>Checkout with Express Pay"]:streamed
-E["CartCount: 3<br/>CartTotal: $149.97"]:streamed
+D["CheckoutButton renders<br/>Checkout with Express Pay"]:info
+E["CartCount: 3<br/>CartTotal: $149.97"]:info
 F(["Page fully interactive<br/>~120ms"]):success
 A --- S
 S --- B
@@ -377,7 +377,7 @@ Compare this to the traditional approach where nothing renders for 350ms.
 
 ### Without promise forwarding (traditional)
 
-<Diagram title="Traditional: slow TTFB, fast render">{`sequenceDiagram
+<Diagram index={5} title="Traditional: slow TTFB, fast render">{`sequenceDiagram
 participant S[Server]
 participant C[Client]
 note over C: Blank screen…
@@ -391,7 +391,7 @@ note over S,C: Slow TTFB, fast render`}</Diagram>
 
 ### With promise forwarding + PPR
 
-<Diagram title="Promise forwarding + PPR: fast TTFB, progressive render">{`sequenceDiagram
+<Diagram index={6} title="Promise forwarding + PPR: fast TTFB, progressive render">{`sequenceDiagram
 participant S[Server]
 participant C[Client]
 S->>S: Start getCart()
@@ -409,7 +409,7 @@ note over S,C: Fast TTFB, progressive render`}</Diagram>
 
 Here's the complete picture of how a request flows through the system with promise forwarding and PPR:
 
-<Diagram title="Full request flow with promise forwarding + PPR">{`flow TD
+<Diagram index={7} title="Full request flow with promise forwarding + PPR">{`flow TD
 subgraph build ["BUILD TIME"]
 B1["Next.js prerenders the route"]
 B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
@@ -424,8 +424,8 @@ R3["Server executes layout"]
 R4["getCart(): fetch in flight"]
 R5["getFlags(): fetch in flight"]
 R6["Promises forwarded<br/>via RSC payload"]
-R7["flags ready<br/>stream HTML"]:streamed
-R8["cart ready<br/>stream HTML"]:streamed
+R7["flags ready<br/>stream HTML"]:info
+R8["cart ready<br/>stream HTML"]:info
 R1 --- R2
 R3 --- R4
 R3 --- R5

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -23,7 +23,7 @@ Modern browsers split rendering into two threads:
 
 When the user scrolls, the input event goes to the **compositor first**. The compositor immediately shifts pre-rasterized pixel tiles on the GPU. No layout, no style recalc, no JS. That's why scrolling stays smooth even when the main thread is blocked.
 
-<Diagram title="Scroll input reaches the compositor first">{`flow LR
+<Diagram index={1} title="Scroll input reaches the compositor first">{`flow LR
 A["User scrolls<br/>(wheel / touch)"]
 B["Compositor thread<br/>receives input"]:primary
 C["GPU shifts pixel tiles<br/>instantly"]:success
@@ -38,7 +38,7 @@ The compositor updates what the user sees **immediately**. The main thread gets 
 
 When JS modifies a transform via `requestAnimationFrame`, the change has to travel through Chromium's full pipeline before it reaches the screen:
 
-<Diagram title="The full Chromium render pipeline">{`flow TD
+<Diagram index={2} title="The full Chromium render pipeline">{`flow TD
 subgraph main ["Main Thread"]
 S["Style"]:primary
 L["Layout"]:primary
@@ -69,7 +69,7 @@ For compositor-driven scroll, **Style, Layout, and Paint can be entirely skipped
 
 Chromium maintains two completely isolated layer trees:
 
-<Diagram title="The two layer trees and how they sync">{`flow LR
+<Diagram index={3} title="The two layer trees and how they sync">{`flow LR
 subgraph main ["Main Thread"]
 LTH["LayerTreeHost<br/>owns main-thread tree"]:primary
 end
@@ -129,9 +129,9 @@ The approach used by [Lenis](https://lenis.darkroom.engineering/) and most WebGL
 
 The canvas is `position: fixed`. It lives in **window** space. Lenis takes over scroll by animating `scrollTop` on each frame via `requestAnimationFrame`. The browser sees real scroll events, so browser features (find-in-page, anchors, accessibility) still work. But because JS is setting `scrollTop`, the main thread controls the pace.
 
-<Diagram title="JS-driven scroll: canvas lives on the window side">{`flow LR
+<Diagram index={4} title="JS-driven scroll: canvas lives on the window side">{`flow LR
 subgraph viewport ["Window (W)"]
-CANVAS["Canvas<br/>(fixed to window)"]:streamed
+CANVAS["Canvas<br/>(fixed to window)"]:info
 VIEW["Viewport<br/>(what user sees)"]:primary
 end
 subgraph page ["Page (P)"]
@@ -164,7 +164,7 @@ function animate(time: number) {
 
 JS drives `scrollTop` each frame, so the compositor and JS are always in agreement. There's no race. The DOM scrolls to exactly where JS told it to, and the canvas renders with the same value.
 
-<Diagram title="JS-driven scroll frame sequence">{`sequenceDiagram
+<Diagram index={5} title="JS-driven scroll frame sequence">{`sequenceDiagram
 participant U[User Input]
 participant M[Main Thread (Lenis)]
 participant C[Compositor]
@@ -196,12 +196,12 @@ The approach used by [Lusion's webgl-scroll-sync](https://github.com/lusionltd/W
 
 The canvas is `position: absolute`. It lives in **page** space, inside the scrolling container. It moves with the DOM naturally on the compositor thread. Each frame, JS reads `scrollY` and applies a `transform` to slide the canvas back into the viewport.
 
-<Diagram title="Absolute: canvas lives on the page side">{`flow LR
+<Diagram index={6} title="Absolute: canvas lives on the page side">{`flow LR
 subgraph viewport ["Window (W)"]
 VIEW["Viewport<br/>(what user sees)"]:primary
 end
 subgraph page ["Page (P)"]
-CANVAS["Canvas<br/>(absolute, in page flow)"]:streamed
+CANVAS["Canvas<br/>(absolute, in page flow)"]:info
 DOM["DOM elements"]:success
 end
 VIEW ===|"D (delta) — JS reads scrollY, applies transform to reposition canvas"| CANVAS`}</Diagram>
@@ -237,7 +237,7 @@ function animate() {
 
 The canvas and DOM move together on the compositor, with no content drift. The only stale thing is the `transform` correction that repositions the canvas over the viewport. Here's what a single scroll looks like:
 
-<Diagram title="Absolute approach: edge drift sequence">{`sequenceDiagram
+<Diagram index={7} title="Absolute approach: edge drift sequence">{`sequenceDiagram
 participant C[Compositor]
 participant P[Page (canvas + DOM)]
 participant M[Main Thread]
@@ -263,7 +263,7 @@ The compositor scroll creates a delta between where the canvas sits (page space)
 
 Edge clipping during fast scroll is solved by rendering the canvas larger than the viewport. Add 25% vertical padding top and bottom (canvas = 150% viewport height). Adding this padding buffer lets the translate catch up when the impl layer syncs. Even with a few frames of stale transform, the extra rendered area covers the viewport:
 
-<Diagram title="Padding absorbs the stale-transform shift">{`flow TD
+<Diagram index={8} title="Padding absorbs the stale-transform shift">{`flow TD
 subgraph canvas ["Canvas (150% viewport height)"]
 PAD_TOP["25% padding (top)<br/>Extra rendered area"]:success
 VP["100% viewport area<br/>What the user actually sees"]:primary
@@ -282,7 +282,7 @@ This is the main tradeoff of the absolute approach. The canvas lives on the **P*
 
 To keep a WebGL element fixed on screen, you don't need to translate anything. It would just sit at its viewport position. The problem is that the canvas is on the page side. When the compositor scrolls, it takes the entire canvas with it, including your "fixed" element. That compositor scroll instantly displaces it. JS hasn't caught up yet, so for that frame the element slides with the page when it should have stayed put. That's the jelly. The element gets dragged by the compositor scroll until the next rAF where JS can correct it back.
 
-<Diagram title="The fixed-element jelly sequence">{`sequenceDiagram
+<Diagram index={9} title="The fixed-element jelly sequence">{`sequenceDiagram
 participant C[Compositor]
 participant P[Page (canvas here)]
 participant M[Main Thread]
@@ -304,7 +304,7 @@ When all your WebGL content scrolls with the page: background effects, image tre
 
 ## Summary
 
-<Diagram title="Choosing a scroll-sync approach">{`flow TD
+<Diagram index={10} title="Choosing a scroll-sync approach">{`flow TD
 ROOT["WebGL canvas needs to<br/>stay in sync with DOM during scroll"]
 PROBLEM["Compositor scrolls instantly (GPU)<br/>JS reads scrollY 1+ frames late"]:warning
 Q{"Where does<br/>the canvas live?"}:primary

--- a/content/logs/11-wtf-is-layout-thrashing.mdx
+++ b/content/logs/11-wtf-is-layout-thrashing.mdx
@@ -10,10 +10,10 @@ Layout thrashing is when JavaScript repeatedly writes to the DOM and then reads 
 
 The browser pipeline for a single frame looks like this (and YOU should know this as the palm of your hand):
 
-<Diagram title="Browser rendering pipeline">{`
+<Diagram index={1} title="Browser rendering pipeline">{`
 flow LR
 js["JS"]:warning
-style["Style"]:streamed
+style["Style"]:info
 layout["Layout"]:primary
 paint["Paint"]:success
 composite["Composite"]:error

--- a/content/logs/12-the-render-pipeline.mdx
+++ b/content/logs/12-the-render-pipeline.mdx
@@ -10,11 +10,11 @@ In [the layout thrashing post](/logs/11-wtf-is-layout-thrashing) we skimmed the 
 
 Every frame the browser produces follows this sequence:
 
-<Diagram title="Full Frame Window — 60fps = 16ms / 120fps = 8ms">{`
+<Diagram index={1} title="Full Frame Window — 60fps = 16ms / 120fps = 8ms">{`
 flow LR
 subgraph main ["Main Thread"]
 js["JS"]:warning
-style["Style"]:streamed
+style["Style"]:info
 layout["Layout"]:primary
 paint["Paint"]:success
 js --- style

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -14,11 +14,11 @@ The long answer is a story. Let me introduce you to Elvira and Homero.
 
 Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
 
-<Diagram title="Stacked branches">{`
+<Diagram index={1} title="Stacked branches">{`
 flow LR
 main["main"]:primary
 elvira["elvira/checkout"]:success
-homero["homero/receipts"]:streamed
+homero["homero/receipts"]:info
 main ===|"base of"| elvira
 elvira ===|"base of"| homero
 `}</Diagram>
@@ -39,7 +39,7 @@ And git explodes. Conflicts in `checkout.ts`. Conflicts in `payment-client.ts`. 
 
 The squash merge took all of Elvira's commits and produced **one brand-new commit** on `main` with the combined diff. Same changes, new hash, no ancestry link back to the originals, which still live inside Homero's branch, because that's where he branched from:
 
-<Diagram>{`
+<Diagram index={2} title="Squash merge: same work, a new hash">{`
 commit A
 commit B
 branch homero/receipts
@@ -93,7 +93,7 @@ git rebase --onto <new-base> <old-base> [<branch>]
 
 Elvira's commits fall outside the `<old-base>..<branch>` range, so they're simply left behind. Only `h1` and `h2` get replayed, and since they never touched Elvira's files, the rebase completes with **zero conflicts**:
 
-<Diagram>{`
+<Diagram index={3} title="After rebase --onto: only your commits replayed">{`
 commit A
 commit B
 commit S : squash of elvira/checkout

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -22,7 +22,7 @@ export function getMDXComponents(
     ...defaultMdxComponents,
     Mermaid,
     Diagram: (props: React.ComponentProps<typeof Diagram>) => (
-      <Diagram articleNumber={articleNumber} {...props} />
+      <Diagram {...props} articleNumber={articleNumber} />
     ),
     CodeTabs: CodeTabs,
     FileCodeblock: FileCodeblock,

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -13,11 +13,17 @@ import { AgentsScriptCommand } from './components/agents-script-command'
 import { Mermaid } from './components/mermaid'
 import { Diagram } from './components/flow'
 
-export function getMDXComponents(components?: MDXComponents): MDXComponents {
+export function getMDXComponents(
+  components?: MDXComponents,
+  opts?: { logNumber?: string | null }
+): MDXComponents {
+  const articleNumber = opts?.logNumber ?? undefined
   return {
     ...defaultMdxComponents,
     Mermaid,
-    Diagram,
+    Diagram: (props: React.ComponentProps<typeof Diagram>) => (
+      <Diagram articleNumber={articleNumber} {...props} />
+    ),
     CodeTabs: CodeTabs,
     FileCodeblock: FileCodeblock,
     Video: ({

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.3.0",
+    "@joycostudio/trazo": "^0.4.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.3.0
-        version: 0.3.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.4.0
+        version: 0.4.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -879,8 +879,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.3.0':
-    resolution: {integrity: sha512-HBS3xx+NnzxouFBtMyhMPiHPdKQId4TW1NhacP0IpEaNJ+vD8wW/1ivUljUzuQmMVOPf7sKYIo4fzM+aQVjQuQ==}
+  '@joycostudio/trazo@0.4.0':
+    resolution: {integrity: sha512-n3eHm1GBAD+W/ZKaE7YOtRlu3oR3P7cXtt/YwcMELbVquaT33An9nxZegjMOO2HZ5WUsHVHYehBefX7DhcNjjg==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6214,7 +6214,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.3.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.4.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0


### PR DESCRIPTION
## What

Fixes the "weird contrast" on some trazo diagram nodes in the logs, plus two small `flow.tsx` hardening changes surfaced while investigating.

## Why

Trazo resolves each fill's label text through a fallback chain (`--trazo-{slot}-fg → --color-{token}-fg → --{token}-fg → hex`), where `success→chart-2`, `info→chart-3`, `warning→chart-4`, and `lane-2..6→chart-1..5`. The repo hand-maintained ~11 `--trazo-*-foreground` overrides per theme instead of pairing each chart fill with a foreground, which left gaps:

- **`info` (used 13× in the logs) had no foreground override** → fell back to the hard-coded dark hex `#0a0a0a` painted on the dark `--chart-3` fill (**~2.2:1 light, ~3.15:1 dark**). This is the visible bug.
- **radio `chart-2` (lane-3) used white** (3.5:1) while `success` on the *same* fill correctly used dark — inconsistent.
- **`--trazo-streamed-foreground` was dead** — `streamed` reads `--trazo-info-foreground`.

## Changes

- **`theming.css`** — replace the fragile per-slot overrides with `--chart-{n}-foreground` pairs. Trazo's token fallback now wires one contrast-checked text color to both the lane slot and the chart-backed role for each fill. Values chosen from **real WCAG ratios** per theme (oklch→sRGB→luminance). Every pair now clears AA except dark-theme `chart-1`, whose fill lightness sits in a dead zone no text color can fix (only used as git `lane-2`; flagged inline).
- **`flow.tsx`**
  - `<figcaption>` is now the first child of `<figure>` (HTML content model requires first-or-last). All overlays are absolutely positioned → **zero visual change**.
  - `layoutFor` derives options from `graphTheme` instead of `joycoTheme`, so both halves of the theme come from one object.
  - `import 'server-only'` — build-time guard so the ~58 KB trazo layout engine can never leak into a client bundle.

## Verification

- `tsc --noEmit` clean
- Logs page renders 200; diagram SVG present in server HTML (server-rendered, not hydrated)
- Trazo appears in **zero** client chunks — the diagram ships as static SVG with no diagram JS payload

_Caveat: server-only behavior verified against the dev build + RSC boundary rules, not a production `pnpm build`. RSC guarantees it holds in prod too._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves Trazo diagram rendering and presentation in log pages. The main changes are:

- Adds chart-level foreground tokens for accessible diagram labels.
- Keeps Trazo parsing and layout on the server.
- Adds framed figures, captions, and per-article diagram tags.
- Updates log diagrams to use indexed labels and the `info` role.
- Updates Trazo from version 0.3 to 0.4.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small diagram metadata cleanup.

- MDX props can override the page-derived article number and display an incorrect corner tag.
- No blocking runtime, build, or security issues were found in the changed code.

mdx-components.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| components/flow.tsx | Adds server-only rendering, shared Trazo theming, semantic figure markup, and optional diagram numbering. |
| app/styles/theming.css | Replaces duplicated Trazo foreground overrides with chart-level foreground pairs for each theme. |
| mdx-components.tsx | Injects the current log number into diagrams, but the MDX props can override that page-derived value. |
| app/(registry)/[[...slug]]/page.tsx | Passes the derived log number into the MDX component factory. |
| package.json | Updates the Trazo dependency to version 0.4. |
| pnpm-lock.yaml | Updates the locked Trazo package and integrity metadata. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
mdx-components.tsx:25
**Page Number Can Be Overridden**

Because `props` is spread after the page-derived value, an MDX diagram with an `articleNumber` prop replaces the actual log number. The corner tag can then display the wrong article identifier, such as `N99-01` on log 07.

```suggestion
      <Diagram {...props} articleNumber={articleNumber} />
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(logs): AA-legible trazo diagram labe..."](https://github.com/joyco-studio/hub/commit/7470320148e13ab6782bed264c5d8f2a13e96a56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44256510)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - Do not use em dashes (—) in prose, frontmatter des... ([source](greptile.json))
- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->