### PR TITLE
chore(logs): temp trazo diagram before/after comparison page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,12 @@ The Components sidebar splits pages into sub-sections based on the `type` frontm
 - **Games** — `type: game`
 
 The type enum is defined in `source.config.ts`. Slug getters live in `lib/source.ts` and are passed through `app/(registry)/layout.tsx` → `RegistrySidebar` → `SidebarSection`.
+
+## Diagram conventions (`<Diagram>` / trazo)
+
+Log diagrams render through the `Diagram` component (`components/flow.tsx`) using the `@joycostudio/trazo` DSL. Two house rules:
+
+- **Arrows/connectors are never colored.** Only node fills carry semantic role color (`:primary`, `:success`, …); every connector renders in the neutral accent color. This is **enforced in code** — `Diagram` strips trazo's per-edge `colored` flag before layout — so a colored token (`===`, `==>`, `<==`, `<==>`) renders identically to its neutral form (`---`, `-->`, `<--`, `<-->`). Prefer the neutral tokens in new DSL for clarity, but either way the render stays neutral. (Git-graph branch lanes are exempt — those are colored by branch on purpose.)
+- **Sequence participants should carry roles.** Give each `participant` a `:role` (e.g. `participant S[Server]:primary`) so the actor boxes are colored, matching the flow diagrams. Keep the role for a given actor consistent across an article (e.g. Main Thread → `:primary`, Compositor → `:success`).
+
+When editing a diagram that also appears on the temporary `/diagram-comparison` review page (`app/diagram-comparison/page.tsx`), update the duplicated DSL in that page's `after` field too.

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -272,14 +272,14 @@ note over S,C: Fast TTFB, progressive render`,
     style R8 fill:#e9d5ff,stroke:#7c3aed,color:#000`,
     },
     after: flow`flow TD
-subgraph build ["BUILD TIME"]
+subgraph build ["BUILD TIME"]:info
 B1["Next.js prerenders the route"]
 B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
 B3[("CDN / Edge Cache")]:primary
 B1 --- B2
 B2 --- B3
 end
-subgraph request ["REQUEST TIME"]
+subgraph request ["REQUEST TIME"]:success
 R1["CDN serves static shell"]
 R2["Browser paints immediately"]:success
 R3["Server executes layout"]
@@ -358,7 +358,7 @@ B --- D`,
     style impl fill:#f0fdf4,stroke:#16a34a,color:#000`,
     },
     after: flow`flow TD
-subgraph main ["Main Thread"]
+subgraph main ["Main Thread"]:info
 S["Style"]:primary
 L["Layout"]:primary
 PP["Pre-paint"]:primary
@@ -367,10 +367,10 @@ S --- L
 L --- PP
 PP --- P
 end
-subgraph commit ["Commit"]
+subgraph commit ["Commit"]:primary
 CO["Copy layer tree +<br/>property trees to impl thread<br/>(main thread blocked)"]:warning
 end
-subgraph impl ["Compositor Thread (impl)"]
+subgraph impl ["Compositor Thread (impl)"]:warning
 LY["Layerize"]:success
 R["Raster<br/>(worker threads → GPU tiles)"]:success
 AC["Activate"]:success

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -1,0 +1,862 @@
+import type { Metadata } from 'next'
+import { Diagram } from '@/components/flow'
+import { Mermaid } from '@/components/mermaid'
+import { ThemeSwitcher } from './theme-switcher'
+
+export const metadata: Metadata = {
+  title: 'Diagram comparison',
+  robots: { index: false, follow: false },
+}
+
+// Temporary review page: every diagram that trazo now renders on the
+// `kahdri/trazo-integration` branch, next to whatever stood in its place on
+// `main` (a Mermaid chart, an Excalidraw screenshot, or a plain-text snippet).
+// Not linked from anywhere — delete once the reviewer has seen the before/after.
+
+type Before =
+  | { kind: 'mermaid'; chart: string }
+  | { kind: 'image'; src: string; width: number; height: number; alt: string }
+  | { kind: 'text'; text: string }
+
+type Pair = {
+  article: string
+  index: number
+  title: string
+  ascii?: boolean
+  before: Before
+  after: string
+}
+
+const PAIRS: Pair[] = [
+  // ── 07 · Next.js promises + PPR ─────────────────────────────────────────
+  {
+    article: '07',
+    index: 1,
+    title: 'Blocking await chain',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    A(["Request arrives"]) --> B["await getCart(), 200ms"]
+    B --> C["await getFlags(), 150ms"]
+    C --> D["Render HTML"]
+    D --> E["Send response, 350ms+ later"]
+
+    style B fill:#fecaca,stroke:#dc2626,color:#000
+    style C fill:#fecaca,stroke:#dc2626,color:#000
+    style E fill:#fecaca,stroke:#dc2626,color:#000`,
+    },
+    after: `flow TD
+A(["Request arrives"]):primary
+B["await getCart()<br/>200ms"]:error
+C["await getFlags()<br/>150ms"]:error
+D["Render HTML"]
+E["Send response<br/>350ms+ later"]:error
+A --- B
+B --- C
+C --- D
+D --- E`,
+  },
+  {
+    article: '07',
+    index: 2,
+    title: 'Forward promises, render shell immediately',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    A(["Request arrives"]) --> B["getCart() started"]
+    A --> C["getFlags() started"]
+    A --> D["Render HTML shell immediately<br/>(with Suspense fallbacks)"]
+
+    B --> E["Stream resolved data<br/>as promises settle"]
+    C --> E
+    D --> E
+
+    style B fill:#bbf7d0,stroke:#16a34a,color:#000
+    style C fill:#bbf7d0,stroke:#16a34a,color:#000
+    style D fill:#bfdbfe,stroke:#2563eb,color:#000
+    style E fill:#bfdbfe,stroke:#2563eb,color:#000`,
+    },
+    after: `flow TD
+A(["Request arrives"]):primary
+B["getCart() started"]:success
+C["getFlags() started"]:success
+D["Render HTML shell immediately<br/>(Suspense fallbacks)"]:primary
+E["Stream resolved data<br/>as promises settle"]:info
+A --- B
+A --- C
+A --- D
+B --- E
+C --- E
+D --- E`,
+  },
+  {
+    article: '07',
+    index: 3,
+    title: 'The static shell: built at build time, served from CDN',
+    before: {
+      kind: 'mermaid',
+      chart: `block-beta
+    columns 1
+    block:shell["Static Shell: built at build time, served from CDN"]
+        columns 2
+        nav["&lt;nav&gt;<br/>Store<br/>&lt;/nav&gt;"]:2
+        skeleton1["CartTotal skeleton"]:1
+        skeleton2["CartCount skeleton"]:1
+        main["&lt;main&gt;<br/>Featured Products"]:2
+        fallback["Checkout button fallback"]:2
+    end
+
+    style nav fill:#bfdbfe,stroke:#2563eb,color:#000
+    style main fill:#bfdbfe,stroke:#2563eb,color:#000
+    style skeleton1 fill:#fef9c3,stroke:#ca8a04,color:#000
+    style skeleton2 fill:#fef9c3,stroke:#ca8a04,color:#000
+    style fallback fill:#fef9c3,stroke:#ca8a04,color:#000`,
+    },
+    after: `flow TD
+shell(["Static Shell: built at build time, served from CDN"])
+nav["<nav> Store </nav>"]:primary
+skeleton1["CartTotal skeleton"]:warning
+skeleton2["CartCount skeleton"]:warning
+main["<main> Featured Products"]:primary
+fallback["Checkout button fallback"]:warning
+shell --- nav
+nav --- skeleton1
+nav --- skeleton2
+skeleton1 --- main
+skeleton2 --- main
+main --- fallback`,
+  },
+  {
+    article: '07',
+    index: 4,
+    title: 'Shell served instantly, dynamic parts stream in',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    A(["Static shell served, 0ms"]) --> S["UI renders with Suspense fallbacks instantly"]
+    S --> B["getFlags resolves, 80ms"]
+    S --> C["getCart resolves, 120ms"]
+
+    B --> D["CheckoutButton renders<br/>Checkout with Express Pay"]
+    C --> E["CartCount: 3<br/>CartTotal: $149.97"]
+
+    D --> F(["Page fully interactive ~120ms"])
+    E --> F
+
+    style A fill:#bfdbfe,stroke:#2563eb,color:#000
+    style S fill:#fef9c3,stroke:#ca8a04,color:#000
+    style B fill:#bbf7d0,stroke:#16a34a,color:#000
+    style C fill:#bbf7d0,stroke:#16a34a,color:#000
+    style D fill:#e9d5ff,stroke:#7c3aed,color:#000
+    style E fill:#e9d5ff,stroke:#7c3aed,color:#000
+    style F fill:#bbf7d0,stroke:#16a34a,color:#000`,
+    },
+    after: `flow TD
+A(["Static shell served<br/>0ms"]):primary
+S["UI renders with<br/>Suspense fallbacks instantly"]:warning
+B["getFlags resolves<br/>80ms"]:success
+C["getCart resolves<br/>120ms"]:success
+D["CheckoutButton renders<br/>Checkout with Express Pay"]:info
+E["CartCount: 3<br/>CartTotal: $149.97"]:info
+F(["Page fully interactive<br/>~120ms"]):success
+A --- S
+S --- B
+S --- C
+B === D
+C === E
+D --- F
+E --- F`,
+  },
+  {
+    article: '07',
+    index: 5,
+    title: 'Traditional: slow TTFB, fast render',
+    before: {
+      kind: 'mermaid',
+      chart: `sequenceDiagram
+    participant S as Server
+    participant C as Client
+
+    Note over C: Blank screen...
+    S->>S: await getCart(), 200ms
+    S->>S: await getFlags(), 150ms
+    S->>S: Render full HTML
+    S->>C: Send response (350ms+ later)
+    C->>C: Display everything at once
+    C->>C: Hydrate
+    Note over S,C: Slow TTFB, fast render`,
+    },
+    after: `sequenceDiagram
+participant S[Server]
+participant C[Client]
+note over C: Blank screen…
+S->>S: await getCart() (200ms)
+S->>S: await getFlags() (150ms)
+S->>S: Render full HTML
+S->>C: Send response (350ms+ later)
+C->>C: Display everything at once
+C->>C: Hydrate
+note over S,C: Slow TTFB, fast render`,
+  },
+  {
+    article: '07',
+    index: 6,
+    title: 'Promise forwarding + PPR: fast TTFB, progressive render',
+    before: {
+      kind: 'mermaid',
+      chart: `sequenceDiagram
+    participant S as Server
+    participant C as Client
+
+    S->>S: Start getCart()
+    S->>S: Start getFlags()
+    S->>C: Static shell + fallbacks (instant)
+    C->>C: Display shell + hydrate static parts
+    Note over C: Users see content immediately
+    S-->>C: Stream flags data
+    C->>C: CheckoutButton resolves
+    S-->>C: Stream cart data
+    C->>C: CartCount + CartTotal pop in
+    Note over S,C: Fast TTFB, progressive render`,
+    },
+    after: `sequenceDiagram
+participant S[Server]
+participant C[Client]
+S->>S: Start getCart()
+S->>S: Start getFlags()
+S->>C: Static shell + fallbacks (instant)
+C->>C: Display shell + hydrate static parts
+note over C: Users see content immediately
+S-->>C: Stream flags data
+C->>C: CheckoutButton resolves
+S-->>C: Stream cart data
+C->>C: CartCount + CartTotal pop in
+note over S,C: Fast TTFB, progressive render`,
+  },
+  {
+    article: '07',
+    index: 7,
+    title: 'Full request flow with promise forwarding + PPR',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    subgraph build ["BUILD TIME"]
+        B1["Next.js prerenders the route"]
+        B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
+        B3[("CDN / Edge Cache")]
+        B1 --> B2 --> B3
+    end
+
+    subgraph request ["REQUEST TIME"]
+        R1["CDN serves static shell"] --> R2["Browser paints immediately"]
+        R3["Server executes layout"]
+        R3 --> R4["getCart(): fetch in flight"]
+        R3 --> R5["getFlags(): fetch in flight"]
+        R4 --> R6["Promises forwarded via<br/>RSC payload"]
+        R5 --> R6
+        R6 --> R7["flags ready<br/>stream HTML"]
+        R6 --> R8["cart ready<br/>stream HTML"]
+    end
+
+    B3 --> R1
+    B3 --> R3
+
+    style build fill:#eff6ff,stroke:#2563eb,color:#000
+    style request fill:#f0fdf4,stroke:#16a34a,color:#000
+    style B3 fill:#bfdbfe,stroke:#2563eb,color:#000
+    style R2 fill:#bbf7d0,stroke:#16a34a,color:#000
+    style R7 fill:#e9d5ff,stroke:#7c3aed,color:#000
+    style R8 fill:#e9d5ff,stroke:#7c3aed,color:#000`,
+    },
+    after: `flow TD
+subgraph build ["BUILD TIME"]
+B1["Next.js prerenders the route"]
+B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
+B3[("CDN / Edge Cache")]:primary
+B1 --- B2
+B2 --- B3
+end
+subgraph request ["REQUEST TIME"]
+R1["CDN serves static shell"]
+R2["Browser paints immediately"]:success
+R3["Server executes layout"]
+R4["getCart(): fetch in flight"]
+R5["getFlags(): fetch in flight"]
+R6["Promises forwarded<br/>via RSC payload"]
+R7["flags ready<br/>stream HTML"]:info
+R8["cart ready<br/>stream HTML"]:info
+R1 --- R2
+R3 --- R4
+R3 --- R5
+R4 --- R6
+R5 --- R6
+R6 === R7
+R6 === R8
+end
+B3 --- R1
+B3 --- R3`,
+  },
+  // ── 08 · WebGL scroll sync ──────────────────────────────────────────────
+  {
+    article: '08',
+    index: 1,
+    title: 'Scroll input reaches the compositor first',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart LR
+    A["User scrolls<br/>(wheel / touch)"] --> B["Compositor thread<br/>receives input"]
+    B --> C["GPU shifts pixel tiles<br/>instantly"]
+    B --> D["Main thread notified<br/>asynchronously"]
+
+    style B fill:#bfdbfe,stroke:#2563eb,color:#000
+    style C fill:#bbf7d0,stroke:#16a34a,color:#000
+    style D fill:#fecaca,stroke:#dc2626,color:#000`,
+    },
+    after: `flow LR
+A["User scrolls<br/>(wheel / touch)"]
+B["Compositor thread<br/>receives input"]:primary
+C["GPU shifts pixel tiles<br/>instantly"]:success
+D["Main thread notified<br/>asynchronously"]:error
+A --- B
+B --- C
+B --- D`,
+  },
+  {
+    article: '08',
+    index: 2,
+    title: 'The full Chromium render pipeline',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    subgraph main ["Main Thread"]
+        direction TB
+        S["Style"] --> L["Layout"]
+        L --> PP["Pre-paint"]
+        PP --> P["Paint<br/>(generate display lists)"]
+    end
+
+    subgraph commit ["Commit"]
+        direction TB
+        CO["Copy layer tree +<br/>property trees to impl thread<br/>(main thread blocked)"]
+    end
+
+    subgraph impl ["Compositor Thread (impl)"]
+        direction TB
+        LY["Layerize"] --> R["Raster<br/>(worker threads → GPU tiles)"]
+        R --> AC["Activate"]
+        AC --> DR["Draw compositor frame"]
+    end
+
+    P --> CO
+    CO --> LY
+
+    style main fill:#eff6ff,stroke:#2563eb,color:#000
+    style commit fill:#fef9c3,stroke:#ca8a04,color:#000
+    style impl fill:#f0fdf4,stroke:#16a34a,color:#000`,
+    },
+    after: `flow TD
+subgraph main ["Main Thread"]
+S["Style"]:primary
+L["Layout"]:primary
+PP["Pre-paint"]:primary
+P["Paint<br/>(generate display lists)"]:primary
+S --- L
+L --- PP
+PP --- P
+end
+subgraph commit ["Commit"]
+CO["Copy layer tree +<br/>property trees to impl thread<br/>(main thread blocked)"]:warning
+end
+subgraph impl ["Compositor Thread (impl)"]
+LY["Layerize"]:success
+R["Raster<br/>(worker threads → GPU tiles)"]:success
+AC["Activate"]:success
+DR["Draw compositor frame"]:success
+LY --- R
+R --- AC
+AC --- DR
+end
+P --- CO
+CO --- LY`,
+  },
+  {
+    article: '08',
+    index: 3,
+    title: 'The two layer trees and how they sync',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart LR
+    subgraph main ["Main Thread"]
+        LTH["LayerTreeHost<br/>owns main-thread tree"]
+    end
+
+    subgraph impl ["Impl Thread"]
+        LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]
+    end
+
+    LTH -- "commit<br/>(periodic sync)" --> LTHI
+    LTHI -- "scroll deltas<br/>(async notify)" --> LTH
+
+    style main fill:#eff6ff,stroke:#2563eb,color:#000
+    style impl fill:#f0fdf4,stroke:#16a34a,color:#000`,
+    },
+    after: `flow LR
+subgraph main ["Main Thread"]
+LTH["LayerTreeHost<br/>owns main-thread tree"]:primary
+end
+subgraph impl ["Impl Thread"]
+LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]:success
+end
+LTH <==>|"commit (sync) / scroll deltas (async)"| LTHI`,
+  },
+  {
+    article: '08',
+    index: 4,
+    title: 'JS-driven scroll: canvas lives on the window side',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart LR
+    subgraph viewport ["Window (W)"]
+        direction TB
+        CANVAS["Canvas<br/>(fixed to window)"]
+        VIEW["Viewport<br/>(what user sees)"]
+    end
+
+    subgraph page ["Page (P)"]
+        direction TB
+        CONTENT["DOM content"]
+    end
+
+    viewport ---|"D (delta)<br/>JS animates scrollTop,<br/>reads it back for canvas"| page
+
+    style viewport fill:#bfdbfe,stroke:#2563eb,color:#000
+    style page fill:#f0fdf4,stroke:#16a34a,color:#000
+    style CANVAS fill:#e9d5ff,stroke:#7c3aed,color:#000
+    style CONTENT fill:#dbeafe,stroke:#3b82f6,color:#000`,
+    },
+    after: `flow LR
+subgraph viewport ["Window (W)"]
+CANVAS["Canvas<br/>(fixed to window)"]:info
+VIEW["Viewport<br/>(what user sees)"]:primary
+end
+subgraph page ["Page (P)"]
+CONTENT["DOM content"]:success
+end
+VIEW ===|"D (delta): JS animates scrollTop, reads it back for canvas"| CONTENT`,
+  },
+  {
+    article: '08',
+    index: 5,
+    title: 'JS-driven scroll frame sequence',
+    before: {
+      kind: 'mermaid',
+      chart: `sequenceDiagram
+    participant U as User Input
+    participant M as Main Thread (Lenis)
+    participant C as Compositor
+    participant S as Screen
+
+    Note over U: User scrolls
+    U->>M: Scroll input
+    Note over M: rAF callback
+    M->>M: Lerp toward target<br/>Set scrollTop<br/>Render WebGL with same value
+    M->>C: Commit layers
+    C->>S: Draw frame
+    Note over S: DOM and canvas<br/>perfectly in sync`,
+    },
+    after: `sequenceDiagram
+participant U[User Input]
+participant M[Main Thread (Lenis)]
+participant C[Compositor]
+participant S[Screen]
+note over U: User scrolls
+U->>M: Scroll input
+note over M: rAF callback
+M->>M: Lerp toward target<br/>Set scrollTop<br/>Render WebGL with same value
+M->>C: Commit layers
+C->>S: Draw frame
+note over S: DOM and canvas<br/>perfectly in sync`,
+  },
+  {
+    article: '08',
+    index: 6,
+    title: 'Absolute: canvas lives on the page side',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart LR
+    subgraph viewport ["Window (W)"]
+        direction TB
+        VIEW["Viewport<br/>(what user sees)"]
+    end
+
+    subgraph page ["Page (P)"]
+        direction TB
+        CANVAS["Canvas<br/>(absolute, in page flow)"]
+        DOM["DOM elements"]
+    end
+
+    viewport ---|"D (delta)<br/>JS reads scrollY,<br/>applies transform<br/>to reposition canvas"| page
+
+    style viewport fill:#bfdbfe,stroke:#2563eb,color:#000
+    style page fill:#f0fdf4,stroke:#16a34a,color:#000
+    style CANVAS fill:#e9d5ff,stroke:#7c3aed,color:#000
+    style DOM fill:#dbeafe,stroke:#3b82f6,color:#000`,
+    },
+    after: `flow LR
+subgraph viewport ["Window (W)"]
+VIEW["Viewport<br/>(what user sees)"]:primary
+end
+subgraph page ["Page (P)"]
+CANVAS["Canvas<br/>(absolute, in page flow)"]:info
+DOM["DOM elements"]:success
+end
+VIEW ===|"D (delta): JS reads scrollY, applies transform to reposition canvas"| CANVAS`,
+  },
+  {
+    article: '08',
+    index: 7,
+    title: 'Absolute approach: edge drift sequence',
+    before: {
+      kind: 'mermaid',
+      chart: `sequenceDiagram
+    participant C as Compositor
+    participant P as Page (canvas + DOM)
+    participant M as Main Thread
+
+    Note over P: Initial state:<br/>scrollY = 500<br/>transform: translateY(500px)<br/>Canvas perfectly covers viewport
+
+    Note over C: User scrolls 40px
+    C->>P: Compositor moves page to scrollY=540<br/>(canvas + DOM shift together, instant)
+    Note over P: Canvas and DOM still aligned with each other<br/>but transform still says 500px<br/>→ 40px gap at the edge
+    Note over M: rAF fires
+    M->>M: Read scrollY = 540
+    M->>P: Update transform to translateY(540px)
+    Note over P: Transform catches up<br/>Canvas covers viewport again`,
+    },
+    after: `sequenceDiagram
+participant C[Compositor]
+participant P[Page (canvas + DOM)]
+participant M[Main Thread]
+note over P: Initial state:<br/>scrollY = 500<br/>transform: translateY(500px)<br/>Canvas perfectly covers viewport
+note over C: User scrolls 40px
+C->>P: Compositor moves page to scrollY=540<br/>(canvas + DOM shift together, instant)
+note over P: Canvas and DOM still aligned<br/>but transform still says 500px<br/>→ 40px gap at the edge
+note over M: rAF fires
+M->>M: Read scrollY = 540
+M->>P: Update transform to translateY(540px)
+note over P: Transform catches up<br/>Canvas covers viewport again`,
+  },
+  {
+    article: '08',
+    index: 8,
+    title: 'Padding absorbs the stale-transform shift',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    subgraph canvas ["Canvas (150% viewport height)"]
+        direction TB
+        PAD_TOP["25% padding (top)<br/>Extra rendered area"]
+        VP["100% viewport area<br/>What the user actually sees"]
+        PAD_BOT["25% padding (bottom)<br/>Extra rendered area"]
+    end
+
+    SCROLL["During fast scroll,<br/>stale transform shifts canvas<br/>a few pixels"] --> VP
+    NOTE["Padding absorbs the shift<br/>→ no visible clipping"] --> VP
+
+    style PAD_TOP fill:#f0fdf4,stroke:#16a34a,color:#000
+    style VP fill:#bfdbfe,stroke:#2563eb,color:#000
+    style PAD_BOT fill:#f0fdf4,stroke:#16a34a,color:#000
+    style NOTE fill:#bbf7d0,stroke:#16a34a,color:#000`,
+    },
+    after: `flow TD
+subgraph canvas ["Canvas (150% viewport height)"]
+PAD_TOP["25% padding (top)<br/>Extra rendered area"]:success
+VP["100% viewport area<br/>What the user actually sees"]:primary
+PAD_BOT["25% padding (bottom)<br/>Extra rendered area"]:success
+PAD_TOP --- VP
+VP --- PAD_BOT
+end
+SCROLL["During fast scroll,<br/>stale transform shifts canvas<br/>a few pixels"]
+NOTE["Padding absorbs the shift<br/>→ no visible clipping"]:success
+SCROLL --- VP
+NOTE --- VP`,
+  },
+  {
+    article: '08',
+    index: 9,
+    title: 'The fixed-element jelly sequence',
+    before: {
+      kind: 'mermaid',
+      chart: `sequenceDiagram
+    participant C as Compositor
+    participant P as Page (canvas here)
+    participant M as Main Thread
+
+    Note over P: "Fixed" element sitting at<br/>its viewport position on the canvas
+    Note over C: User scrolls 40px
+    C->>P: Compositor moves page to scrollY=540<br/>(entire canvas shifts, including the "fixed" element)
+    Note over P: Element dragged 40px with the page<br/>→ visibly displaced from where it should be
+    Note over M: rAF fires: reads scrollY=540
+    M->>M: Correct element position back<br/>to where it should be on screen
+    Note over P: Element snaps back into place<br/>but for that frame it was wrong → jelly`,
+    },
+    after: `sequenceDiagram
+participant C[Compositor]
+participant P[Page (canvas here)]
+participant M[Main Thread]
+note over P: "Fixed" element sitting at<br/>its viewport position on the canvas
+note over C: User scrolls 40px
+C->>P: Compositor moves page to scrollY=540<br/>(entire canvas shifts, including the "fixed" element)
+note over P: Element dragged 40px with the page<br/>→ visibly displaced from where it should be
+note over M: rAF fires: reads scrollY=540
+M->>M: Correct element position back<br/>to where it should be on screen
+note over P: Element snaps back into place<br/>but for that frame it was wrong → jelly`,
+  },
+  {
+    article: '08',
+    index: 10,
+    title: 'Choosing a scroll-sync approach',
+    before: {
+      kind: 'mermaid',
+      chart: `flowchart TD
+    ROOT["WebGL canvas needs to<br/>stay in sync with DOM during scroll"]
+    ROOT --> PROBLEM["Compositor scrolls instantly (GPU)<br/>JS reads scrollY 1+ frames late"]
+    PROBLEM --> Q{"Where does<br/>the canvas live?"}
+
+    Q --> FIXED["Window side (fixed)"]
+    Q --> ABS["Page side (absolute)"]
+
+    FIXED --> FIX_HOW["JS-driven scroll (Lenis):<br/>JS animates scrollTop<br/>Canvas reads it back"]
+    FIX_HOW --> FIX_PRO["Zero drift between<br/>DOM and canvas"]
+    FIX_HOW --> FIX_CON["Main-thread scrolling<br/>Can drop frames on mobile"]
+
+    ABS --> ABS_HOW["Keep native scroll:<br/>Canvas moves with page<br/>Transform corrects position"]
+    ABS_HOW --> ABS_PRO["Native scroll preserved<br/>Content stays aligned"]
+    ABS_HOW --> ABS_CON["Edge clipping (fix with padding)<br/>Viewport-fixed WebGL elements drift"]
+
+    style PROBLEM fill:#fef9c3,stroke:#ca8a04,color:#000
+    style FIXED fill:#bfdbfe,stroke:#2563eb,color:#000
+    style ABS fill:#f0fdf4,stroke:#16a34a,color:#000
+    style FIX_PRO fill:#bbf7d0,stroke:#16a34a,color:#000
+    style FIX_CON fill:#fecaca,stroke:#dc2626,color:#000
+    style ABS_PRO fill:#bbf7d0,stroke:#16a34a,color:#000
+    style ABS_CON fill:#fecaca,stroke:#dc2626,color:#000`,
+    },
+    after: `flow TD
+ROOT["WebGL canvas needs to<br/>stay in sync with DOM during scroll"]
+PROBLEM["Compositor scrolls instantly (GPU)<br/>JS reads scrollY 1+ frames late"]:warning
+Q{"Where does<br/>the canvas live?"}:primary
+FIXED["Window side (fixed)"]:primary
+ABS["Page side (absolute)"]:success
+FIX_HOW["JS-driven scroll (Lenis):<br/>JS animates scrollTop<br/>Canvas reads it back"]
+FIX_PRO["Zero drift between<br/>DOM and canvas"]:success
+FIX_CON["Main-thread scrolling<br/>Can drop frames on mobile"]:error
+ABS_HOW["Keep native scroll:<br/>Canvas moves with page<br/>Transform corrects position"]
+ABS_PRO["Native scroll preserved<br/>Content stays aligned"]:success
+ABS_CON["Edge clipping (fix with padding)<br/>Viewport-fixed WebGL elements drift"]:error
+ROOT --- PROBLEM
+PROBLEM --- Q
+Q --- FIXED
+Q --- ABS
+FIXED --- FIX_HOW
+FIX_HOW --- FIX_PRO
+FIX_HOW --- FIX_CON
+ABS --- ABS_HOW
+ABS_HOW --- ABS_PRO
+ABS_HOW --- ABS_CON`,
+  },
+  // ── 11 · Layout thrashing (was an Excalidraw screenshot) ────────────────
+  {
+    article: '11',
+    index: 1,
+    title: 'Browser rendering pipeline',
+    before: {
+      kind: 'image',
+      src: 'https://r2.joyco.studio/nbOp4PikfFPi.png',
+      width: 1903,
+      height: 520,
+      alt: 'Browser rendering pipeline',
+    },
+    after: `flow LR
+js["JS"]:warning
+style["Style"]:info
+layout["Layout"]:primary
+paint["Paint"]:success
+composite["Composite"]:error
+js --- style
+style --- layout
+layout --- paint
+paint --- composite
+cry["this one makes fps cry 😢"]:neutral
+cry --> layout`,
+  },
+  // ── 12 · The render pipeline (was an Excalidraw screenshot) ─────────────
+  {
+    article: '12',
+    index: 1,
+    title: 'Full Frame Window — 60fps = 16ms / 120fps = 8ms',
+    before: {
+      kind: 'image',
+      src: 'https://r2.joyco.studio/hTyqgeONsgOA.jpg',
+      width: 1903,
+      height: 520,
+      alt: 'Browser rendering pipeline',
+    },
+    after: `flow LR
+subgraph main ["Main Thread"]
+js["JS"]:warning
+style["Style"]:info
+layout["Layout"]:primary
+paint["Paint"]:success
+js --- style
+style --- layout
+layout --- paint
+end
+subgraph compositor ["Compositor Thread"]
+composite["Composite"]:error
+end
+paint === composite`,
+  },
+  // ── 14 · Phantom merge conflicts (was plain-text / ASCII snippets) ──────
+  {
+    article: '14',
+    index: 1,
+    title: 'Stacked branches',
+    before: { kind: 'text', text: `main ← elvira/checkout ← homero/receipts` },
+    after: `flow LR
+main["main"]:primary
+elvira["elvira/checkout"]:success
+homero["homero/receipts"]:info
+main ===|"base of"| elvira
+elvira ===|"base of"| homero`,
+  },
+  {
+    article: '14',
+    index: 2,
+    title: 'Squash merge: same work, a new hash',
+    ascii: true,
+    before: {
+      kind: 'text',
+      text: `main:              A ── B ───────── S        (S = squash of elvira/checkout)
+                          \\
+homero/receipts:           e1 ── e2 ── h1 ── h2
+                          └ Elvira's ┘└ Homero's ┘
+                             commits      commits`,
+    },
+    after: `main:              A ── B ───────── S        (S = squash of elvira/checkout)
+                            \\
+homero/receipts:           e1 ── e2 ── h1 ── h2
+                           └ Elvira's ┘└ Homero's ┘`,
+  },
+  {
+    article: '14',
+    index: 3,
+    title: 'After rebase --onto: only your commits replayed',
+    ascii: true,
+    before: {
+      kind: 'text',
+      text: `main:              A ── B ── S
+                                 \\
+homero/receipts:                  h1' ── h2'`,
+    },
+    after: `main:              A ── B ── S
+                            \\
+homero/receipts:           h1' ── h2'`,
+  },
+]
+
+function BeforePanel({ before }: { before: Before }) {
+  if (before.kind === 'mermaid') {
+    return <Mermaid chart={before.chart} />
+  }
+  if (before.kind === 'image') {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={before.src}
+        alt={before.alt}
+        width={before.width}
+        height={before.height}
+        className="mx-auto h-auto max-w-full"
+      />
+    )
+  }
+  return (
+    <div className="overflow-x-auto px-4 py-8">
+      <pre className="text-foreground/90 w-fit min-w-full font-mono text-[13px] leading-relaxed whitespace-pre">
+        {before.text}
+      </pre>
+    </div>
+  )
+}
+
+export default function DiagramComparisonPage() {
+  return (
+    <div className="min-h-screen">
+      <ThemeSwitcher />
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        <header className="mb-12">
+          <h1 className="font-heading text-3xl font-medium tracking-tight">
+            Trazo diagram comparison
+          </h1>
+          <p className="text-muted-foreground mt-3 max-w-2xl text-pretty">
+            Every diagram now rendered with{' '}
+            <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">
+              @joycostudio/trazo
+            </code>{' '}
+            on this branch, next to the original that lived on{' '}
+            <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">
+              main
+            </code>{' '}
+            — a Mermaid chart, an Excalidraw screenshot, or a plain-text
+            snippet. {PAIRS.length} diagrams across 5 logs.
+          </p>
+        </header>
+
+        <div className="flex flex-col gap-16">
+          {PAIRS.map((pair) => (
+            <section key={`${pair.article}-${pair.index}`}>
+              <div className="border-border mb-4 flex items-baseline gap-3 border-b pb-2">
+                <span className="text-muted-foreground font-mono text-xs tabular-nums">
+                  N{pair.article}-{String(pair.index).padStart(2, '0')}
+                </span>
+                <h2 className="font-heading text-lg font-medium">
+                  {pair.title}
+                </h2>
+              </div>
+              <div className="grid gap-6 lg:grid-cols-2">
+                <div>
+                  <p className="text-muted-foreground mb-2 font-mono text-xs uppercase">
+                    Before ·{' '}
+                    {pair.before.kind === 'mermaid'
+                      ? 'Mermaid'
+                      : pair.before.kind === 'image'
+                        ? 'Excalidraw screenshot'
+                        : 'Plain text'}
+                  </p>
+                  <div className="border-border bg-card flex min-h-[8rem] items-center justify-center border p-2">
+                    <BeforePanel before={pair.before} />
+                  </div>
+                </div>
+                <div>
+                  <p className="text-muted-foreground mb-2 font-mono text-xs uppercase">
+                    After · Trazo{pair.ascii ? ' (ASCII)' : ''}
+                  </p>
+                  <Diagram
+                    index={pair.index}
+                    articleNumber={pair.article}
+                    title={pair.title}
+                    ascii={pair.ascii}
+                    className="my-0!"
+                  >
+                    {pair.after}
+                  </Diagram>
+                </div>
+              </div>
+            </section>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -187,8 +187,8 @@ E --- F`,
     Note over S,C: Slow TTFB, fast render`,
     },
     after: `sequenceDiagram
-participant S[Server]
-participant C[Client]
+participant S[Server]:primary
+participant C[Client]:success
 note over C: Blank screen…
 S->>S: await getCart() (200ms)
 S->>S: await getFlags() (150ms)
@@ -220,8 +220,8 @@ note over S,C: Slow TTFB, fast render`,
     Note over S,C: Fast TTFB, progressive render`,
     },
     after: `sequenceDiagram
-participant S[Server]
-participant C[Client]
+participant S[Server]:primary
+participant C[Client]:success
 S->>S: Start getCart()
 S->>S: Start getFlags()
 S->>C: Static shell + fallbacks (instant)
@@ -466,10 +466,10 @@ VIEW ===|D (delta): JS animates scrollTop,<br/>reads it back for canvas| CONTENT
     Note over S: DOM and canvas<br/>perfectly in sync`,
     },
     after: `sequenceDiagram
-participant U[User Input]
-participant M[Main Thread (Lenis)]
-participant C[Compositor]
-participant S[Screen]
+participant U[User Input]:warning
+participant M[Main Thread (Lenis)]:primary
+participant C[Compositor]:success
+participant S[Screen]:info
 note over U: User scrolls
 U->>M: Scroll input
 note over M: rAF callback
@@ -535,9 +535,9 @@ VIEW ===|D (delta): JS reads scrollY,<br/>applies transform to reposition canvas
     Note over P: Transform catches up<br/>Canvas covers viewport again`,
     },
     after: `sequenceDiagram
-participant C[Compositor]
-participant P[Page (canvas + DOM)]
-participant M[Main Thread]
+participant C[Compositor]:success
+participant P[Page (canvas + DOM)]:info
+participant M[Main Thread]:primary
 note over P: Initial state:<br/>scrollY = 500<br/>transform: translateY(500px)<br/>Canvas perfectly covers viewport
 note over C: User scrolls 40px
 C->>P: Compositor moves page to scrollY=540<br/>(canvas + DOM shift together, instant)
@@ -602,9 +602,9 @@ NOTE --- VP`,
     Note over P: Element snaps back into place<br/>but for that frame it was wrong → jelly`,
     },
     after: `sequenceDiagram
-participant C[Compositor]
-participant P[Page (canvas here)]
-participant M[Main Thread]
+participant C[Compositor]:success
+participant P[Page (canvas here)]:info
+participant M[Main Thread]:primary
 note over P: "Fixed" element sitting at<br/>its viewport position on the canvas
 note over C: User scrolls 40px
 C->>P: Compositor moves page to scrollY=540<br/>(entire canvas shifts, including the "fixed" element)

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -407,7 +407,8 @@ end
 subgraph impl ["Impl Thread"]
 LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]:success
 end
-LTH <==>|commit (sync) / scroll deltas (async)| LTHI`,
+LTH -->|commit (periodic sync)| LTHI
+LTHI -->|scroll deltas (async notify)| LTH`,
   },
   {
     article: '08',
@@ -721,9 +722,13 @@ paint === composite`,
     article: '14',
     index: 1,
     title: 'Stacked branches',
-    ascii: true,
     before: { kind: 'text', text: `main ← elvira/checkout ← homero/receipts` },
-    after: `main ◀── based on ── elvira/checkout ◀── based on ── homero/receipts`,
+    after: `flow LR
+main["main"]:primary
+elvira["elvira/checkout"]:success
+homero["homero/receipts"]:info
+main ===|base of| elvira
+elvira ===|base of| homero`,
   },
   {
     article: '14',

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -443,7 +443,7 @@ end
 subgraph page ["Page (P)"]
 CONTENT["DOM content"]:success
 end
-VIEW ===|D (delta): JS animates scrollTop, reads it back for canvas| CONTENT`,
+VIEW ===|D (delta): JS animates scrollTop,<br/>reads it back for canvas| CONTENT`,
   },
   {
     article: '08',
@@ -511,7 +511,7 @@ subgraph page ["Page (P)"]
 CANVAS["Canvas<br/>(absolute, in page flow)"]:info
 DOM["DOM elements"]:success
 end
-VIEW ===|D (delta): JS reads scrollY, applies transform to reposition canvas| CANVAS`,
+VIEW ===|D (delta): JS reads scrollY,<br/>applies transform to reposition canvas| CANVAS`,
   },
   {
     article: '08',
@@ -727,8 +727,8 @@ paint === composite`,
 main["main"]:primary
 elvira["elvira/checkout"]:success
 homero["homero/receipts"]:info
-main ===|base of| elvira
-elvira ===|base of| homero`,
+main <==|base of| elvira
+elvira <==|base of| homero`,
   },
   {
     article: '14',

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -47,8 +47,8 @@ const PAIRS: Pair[] = [
     },
     after: `flow TD
 A(["Request arrives"]):primary
-B["await getCart()<br/>200ms"]:error
-C["await getFlags()<br/>150ms"]:error
+B["await \`getCart()\`<br/>200ms"]:error
+C["await \`getFlags()\`<br/>150ms"]:error
 D["Render HTML"]
 E["Send response<br/>350ms+ later"]:error
 A --- B
@@ -78,9 +78,9 @@ D --- E`,
     },
     after: `flow TD
 A(["Request arrives"]):primary
-B["getCart() started"]:success
-C["getFlags() started"]:success
-D["Render HTML shell immediately<br/>(Suspense fallbacks)"]:primary
+B["\`getCart()\` started"]:success
+C["\`getFlags()\` started"]:success
+D["Render HTML shell immediately<br/>(\`<Suspense>\` fallbacks)"]:primary
 E["Stream resolved data<br/>as promises settle"]:info
 A --- B
 A --- C
@@ -114,11 +114,11 @@ D --- E`,
     },
     after: `flow TD
 shell(["Static Shell: built at build time, served from CDN"])
-nav["<nav> Store </nav>"]:primary
-skeleton1["CartTotal skeleton"]:warning
-skeleton2["CartCount skeleton"]:warning
-main["<main> Featured Products"]:primary
-fallback["Checkout button fallback"]:warning
+nav["\`<nav>\` Store \`</nav>\`"]:primary
+skeleton1["\`CartTotal\` skeleton"]:warning
+skeleton2["\`CartCount\` skeleton"]:warning
+main["\`<main>\` Featured Products"]:primary
+fallback["\`CheckoutButton\` fallback"]:warning
 shell --- nav
 nav --- skeleton1
 nav --- skeleton2
@@ -153,11 +153,11 @@ main --- fallback`,
     },
     after: `flow TD
 A(["Static shell served<br/>0ms"]):primary
-S["UI renders with<br/>Suspense fallbacks instantly"]:warning
-B["getFlags resolves<br/>80ms"]:success
-C["getCart resolves<br/>120ms"]:success
-D["CheckoutButton renders<br/>Checkout with Express Pay"]:info
-E["CartCount: 3<br/>CartTotal: $149.97"]:info
+S["UI renders with<br/>\`<Suspense>\` fallbacks instantly"]:warning
+B["\`getFlags()\` resolves<br/>80ms"]:success
+C["\`getCart()\` resolves<br/>120ms"]:success
+D["\`CheckoutButton\` renders<br/>Checkout with Express Pay"]:info
+E["\`CartCount\`: 3<br/>\`CartTotal\`: $149.97"]:info
 F(["Page fully interactive<br/>~120ms"]):success
 A --- S
 S --- B
@@ -407,7 +407,7 @@ end
 subgraph impl ["Impl Thread"]
 LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]:success
 end
-LTH <==>|"commit (sync) / scroll deltas (async)"| LTHI`,
+LTH <==>|commit (sync) / scroll deltas (async)| LTHI`,
   },
   {
     article: '08',
@@ -442,7 +442,7 @@ end
 subgraph page ["Page (P)"]
 CONTENT["DOM content"]:success
 end
-VIEW ===|"D (delta): JS animates scrollTop, reads it back for canvas"| CONTENT`,
+VIEW ===|D (delta): JS animates scrollTop, reads it back for canvas| CONTENT`,
   },
   {
     article: '08',
@@ -510,7 +510,7 @@ subgraph page ["Page (P)"]
 CANVAS["Canvas<br/>(absolute, in page flow)"]:info
 DOM["DOM elements"]:success
 end
-VIEW ===|"D (delta): JS reads scrollY, applies transform to reposition canvas"| CANVAS`,
+VIEW ===|D (delta): JS reads scrollY, applies transform to reposition canvas| CANVAS`,
   },
   {
     article: '08',
@@ -687,8 +687,7 @@ js --- style
 style --- layout
 layout --- paint
 paint --- composite
-cry["this one makes fps cry 😢"]:neutral
-cry --> layout`,
+note layout below "this one makes fps cry 😢"`,
   },
   // ── 12 · The render pipeline (was an Excalidraw screenshot) ─────────────
   {
@@ -722,13 +721,9 @@ paint === composite`,
     article: '14',
     index: 1,
     title: 'Stacked branches',
+    ascii: true,
     before: { kind: 'text', text: `main ← elvira/checkout ← homero/receipts` },
-    after: `flow LR
-main["main"]:primary
-elvira["elvira/checkout"]:success
-homero["homero/receipts"]:info
-main ===|"base of"| elvira
-elvira ===|"base of"| homero`,
+    after: `main ◀── based on ── elvira/checkout ◀── based on ── homero/receipts`,
   },
   {
     article: '14',

--- a/app/diagram-comparison/page.tsx
+++ b/app/diagram-comparison/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
-import { Diagram } from '@/components/flow'
+import { flow, seq } from '@joycostudio/trazo'
+import { Diagram, type DiagramGraph } from '@/components/flow'
 import { Mermaid } from '@/components/mermaid'
 import { ThemeSwitcher } from './theme-switcher'
 
@@ -24,7 +25,9 @@ type Pair = {
   title: string
   ascii?: boolean
   before: Before
-  after: string
+  // A `flow`/`seq` tagged-template graph (validated at build time), or a raw
+  // string for `ascii` figures.
+  after: string | DiagramGraph
 }
 
 const PAIRS: Pair[] = [
@@ -45,7 +48,7 @@ const PAIRS: Pair[] = [
     style C fill:#fecaca,stroke:#dc2626,color:#000
     style E fill:#fecaca,stroke:#dc2626,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 A(["Request arrives"]):primary
 B["await \`getCart()\`<br/>200ms"]:error
 C["await \`getFlags()\`<br/>150ms"]:error
@@ -76,7 +79,7 @@ D --- E`,
     style D fill:#bfdbfe,stroke:#2563eb,color:#000
     style E fill:#bfdbfe,stroke:#2563eb,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 A(["Request arrives"]):primary
 B["\`getCart()\` started"]:success
 C["\`getFlags()\` started"]:success
@@ -112,7 +115,7 @@ D --- E`,
     style skeleton2 fill:#fef9c3,stroke:#ca8a04,color:#000
     style fallback fill:#fef9c3,stroke:#ca8a04,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 shell(["Static Shell: built at build time, served from CDN"])
 nav["\`<nav>\` Store \`</nav>\`"]:primary
 skeleton1["\`CartTotal\` skeleton"]:warning
@@ -151,7 +154,7 @@ main --- fallback`,
     style E fill:#e9d5ff,stroke:#7c3aed,color:#000
     style F fill:#bbf7d0,stroke:#16a34a,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 A(["Static shell served<br/>0ms"]):primary
 S["UI renders with<br/>\`<Suspense>\` fallbacks instantly"]:warning
 B["\`getFlags()\` resolves<br/>80ms"]:success
@@ -186,7 +189,7 @@ E --- F`,
     C->>C: Hydrate
     Note over S,C: Slow TTFB, fast render`,
     },
-    after: `sequenceDiagram
+    after: seq`sequenceDiagram
 participant S[Server]:primary
 participant C[Client]:success
 note over C: Blank screen…
@@ -219,7 +222,7 @@ note over S,C: Slow TTFB, fast render`,
     C->>C: CartCount + CartTotal pop in
     Note over S,C: Fast TTFB, progressive render`,
     },
-    after: `sequenceDiagram
+    after: seq`sequenceDiagram
 participant S[Server]:primary
 participant C[Client]:success
 S->>S: Start getCart()
@@ -268,7 +271,7 @@ note over S,C: Fast TTFB, progressive render`,
     style R7 fill:#e9d5ff,stroke:#7c3aed,color:#000
     style R8 fill:#e9d5ff,stroke:#7c3aed,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 subgraph build ["BUILD TIME"]
 B1["Next.js prerenders the route"]
 B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
@@ -312,7 +315,7 @@ B3 --- R3`,
     style C fill:#bbf7d0,stroke:#16a34a,color:#000
     style D fill:#fecaca,stroke:#dc2626,color:#000`,
     },
-    after: `flow LR
+    after: flow`flow LR
 A["User scrolls<br/>(wheel / touch)"]
 B["Compositor thread<br/>receives input"]:primary
 C["GPU shifts pixel tiles<br/>instantly"]:success
@@ -354,7 +357,7 @@ B --- D`,
     style commit fill:#fef9c3,stroke:#ca8a04,color:#000
     style impl fill:#f0fdf4,stroke:#16a34a,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 subgraph main ["Main Thread"]
 S["Style"]:primary
 L["Layout"]:primary
@@ -400,7 +403,7 @@ CO --- LY`,
     style main fill:#eff6ff,stroke:#2563eb,color:#000
     style impl fill:#f0fdf4,stroke:#16a34a,color:#000`,
     },
-    after: `flow LR
+    after: flow`flow LR
 subgraph main ["Main Thread"]
 LTH["LayerTreeHost<br/>owns main-thread tree"]:primary
 end
@@ -435,7 +438,7 @@ LTHI -->|scroll deltas (async notify)| LTH`,
     style CANVAS fill:#e9d5ff,stroke:#7c3aed,color:#000
     style CONTENT fill:#dbeafe,stroke:#3b82f6,color:#000`,
     },
-    after: `flow LR
+    after: flow`flow LR
 subgraph viewport ["Window (W)"]
 CANVAS["Canvas<br/>(fixed to window)"]:info
 VIEW["Viewport<br/>(what user sees)"]:primary
@@ -465,7 +468,7 @@ VIEW ===|D (delta): JS animates scrollTop,<br/>reads it back for canvas| CONTENT
     C->>S: Draw frame
     Note over S: DOM and canvas<br/>perfectly in sync`,
     },
-    after: `sequenceDiagram
+    after: seq`sequenceDiagram
 participant U[User Input]:warning
 participant M[Main Thread (Lenis)]:primary
 participant C[Compositor]:success
@@ -503,7 +506,7 @@ note over S: DOM and canvas<br/>perfectly in sync`,
     style CANVAS fill:#e9d5ff,stroke:#7c3aed,color:#000
     style DOM fill:#dbeafe,stroke:#3b82f6,color:#000`,
     },
-    after: `flow LR
+    after: flow`flow LR
 subgraph viewport ["Window (W)"]
 VIEW["Viewport<br/>(what user sees)"]:primary
 end
@@ -534,7 +537,7 @@ VIEW ===|D (delta): JS reads scrollY,<br/>applies transform to reposition canvas
     M->>P: Update transform to translateY(540px)
     Note over P: Transform catches up<br/>Canvas covers viewport again`,
     },
-    after: `sequenceDiagram
+    after: seq`sequenceDiagram
 participant C[Compositor]:success
 participant P[Page (canvas + DOM)]:info
 participant M[Main Thread]:primary
@@ -569,13 +572,11 @@ note over P: Transform catches up<br/>Canvas covers viewport again`,
     style PAD_BOT fill:#f0fdf4,stroke:#16a34a,color:#000
     style NOTE fill:#bbf7d0,stroke:#16a34a,color:#000`,
     },
-    after: `flow TD
-subgraph canvas ["Canvas (150% viewport height)"]
+    after: flow`flow TD
+subgraph canvas ["Canvas (150% viewport height)"]:info
 PAD_TOP["25% padding (top)<br/>Extra rendered area"]:success
 VP["100% viewport area<br/>What the user actually sees"]:primary
 PAD_BOT["25% padding (bottom)<br/>Extra rendered area"]:success
-PAD_TOP --- VP
-VP --- PAD_BOT
 end
 SCROLL["During fast scroll,<br/>stale transform shifts canvas<br/>a few pixels"]
 NOTE["Padding absorbs the shift<br/>→ no visible clipping"]:success
@@ -601,7 +602,7 @@ NOTE --- VP`,
     M->>M: Correct element position back<br/>to where it should be on screen
     Note over P: Element snaps back into place<br/>but for that frame it was wrong → jelly`,
     },
-    after: `sequenceDiagram
+    after: seq`sequenceDiagram
 participant C[Compositor]:success
 participant P[Page (canvas here)]:info
 participant M[Main Thread]:primary
@@ -643,7 +644,7 @@ note over P: Element snaps back into place<br/>but for that frame it was wrong �
     style ABS_PRO fill:#bbf7d0,stroke:#16a34a,color:#000
     style ABS_CON fill:#fecaca,stroke:#dc2626,color:#000`,
     },
-    after: `flow TD
+    after: flow`flow TD
 ROOT["WebGL canvas needs to<br/>stay in sync with DOM during scroll"]
 PROBLEM["Compositor scrolls instantly (GPU)<br/>JS reads scrollY 1+ frames late"]:warning
 Q{"Where does<br/>the canvas live?"}:primary
@@ -678,7 +679,7 @@ ABS_HOW --- ABS_CON`,
       height: 520,
       alt: 'Browser rendering pipeline',
     },
-    after: `flow LR
+    after: flow`flow LR
 js["JS"]:warning
 style["Style"]:info
 layout["Layout"]:primary
@@ -702,7 +703,7 @@ note layout below "this one makes fps cry 😢"`,
       height: 520,
       alt: 'Browser rendering pipeline',
     },
-    after: `flow LR
+    after: flow`flow LR
 subgraph main ["Main Thread"]
 js["JS"]:warning
 style["Style"]:info
@@ -712,7 +713,7 @@ js --- style
 style --- layout
 layout --- paint
 end
-subgraph compositor ["Compositor Thread"]
+subgraph compositor ["Compositor Thread"]:error
 composite["Composite"]:error
 end
 paint === composite`,
@@ -723,7 +724,7 @@ paint === composite`,
     index: 1,
     title: 'Stacked branches',
     before: { kind: 'text', text: `main ← elvira/checkout ← homero/receipts` },
-    after: `flow LR
+    after: flow`flow LR
 main["main"]:primary
 elvira["elvira/checkout"]:success
 homero["homero/receipts"]:info
@@ -771,7 +772,6 @@ function BeforePanel({ before }: { before: Before }) {
   }
   if (before.kind === 'image') {
     return (
-      // eslint-disable-next-line @next/next/no-img-element
       <img
         src={before.src}
         alt={before.alt}

--- a/app/diagram-comparison/theme-switcher.tsx
+++ b/app/diagram-comparison/theme-switcher.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { cn } from '@/lib/utils'
+
+const THEMES = ['light', 'dark', 'radio', 'terminal'] as const
+
+export function ThemeSwitcher() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <div className="bg-card sticky top-0 z-20 flex items-center gap-2 border-b px-6 py-3">
+      <span className="text-muted-foreground mr-2 font-mono text-xs uppercase">
+        Theme
+      </span>
+      {THEMES.map((t) => (
+        <button
+          key={t}
+          type="button"
+          onClick={() => setTheme(t)}
+          className={cn(
+            'border-border rounded-md border px-3 py-1 font-mono text-xs uppercase transition-colors',
+            theme === t
+              ? 'bg-primary text-primary-foreground'
+              : 'hover:bg-accent'
+          )}
+        >
+          {t}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/app/styles/theming.css
+++ b/app/styles/theming.css
@@ -25,11 +25,11 @@
   --preview-foreground: var(--card-foreground);
   --code-highlight: oklch(0.96 0 0);
   --code-number: oklch(0.56 0 0 / 0.5);
-  --chart-1: oklch(0.50 0.22 263);
+  --chart-1: oklch(0.5 0.22 263);
   --chart-2: oklch(0.62 0.18 243);
   --chart-3: oklch(0.42 0.16 283);
-  --chart-4: oklch(0.70 0.12 253);
-  --chart-5: oklch(0.55 0.10 273);
+  --chart-4: oklch(0.896 0.052 282.912);
+  --chart-5: oklch(0.55 0.1 273);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -80,10 +80,10 @@
   --preview-foreground: var(--card-foreground);
   --code-highlight: oklch(0.27 0 0);
   --code-number: oklch(0.72 0 0 / 0.5);
-  --chart-1: oklch(0.58 0.20 263);
-  --chart-2: oklch(0.70 0.16 243);
-  --chart-3: oklch(0.50 0.14 283);
-  --chart-4: oklch(0.78 0.10 253);
+  --chart-1: oklch(0.58 0.2 263);
+  --chart-2: oklch(0.7 0.16 243);
+  --chart-3: oklch(0.5 0.14 283);
+  --chart-4: oklch(0.78 0.1 253);
   --chart-5: oklch(0.63 0.08 273);
 
   --chart-1-foreground: oklch(0.145 0 0);
@@ -129,11 +129,11 @@
   --preview-foreground: var(--card-foreground);
   --code-highlight: oklch(0.935 0.025 250);
   --code-number: oklch(0.5 0.025 250 / 0.5);
-  --chart-1: oklch(0.50 0.22 263);
+  --chart-1: oklch(0.5 0.22 263);
   --chart-2: oklch(0.62 0.18 243);
   --chart-3: oklch(0.42 0.16 283);
-  --chart-4: oklch(0.70 0.12 253);
-  --chart-5: oklch(0.55 0.10 273);
+  --chart-4: oklch(0.7 0.12 253);
+  --chart-5: oklch(0.55 0.1 273);
 
   --chart-1-foreground: oklch(1 0 0);
   --chart-2-foreground: oklch(0.145 0 0);

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -41,7 +41,7 @@ const graphTheme: TrazoTheme = {
     success: 'var(--color-mint-green)',
     code: 'oklch(1 0 0 / 0.16)',
     'code-foreground': 'inherit',
-    
+    muted: 'lab(17.06 0 0 / 0.8)',
   },
 }
 

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -30,7 +30,12 @@ import { cn } from '@/lib/utils'
 const graphTheme: TrazoTheme = {
   ...joycoTheme,
   background: 'none',
-  tokens: { ...joycoTheme.tokens, bg: 'var(--card)' },
+  tokens: {
+    ...joycoTheme.tokens,
+    bg: 'var(--card)',
+    'neutral-foreground': 'var(--muted)',
+    success: 'var(--color-mint-green)',
+  },
 }
 
 // Git branches map onto lane-1, lane-2, … in commit order. This app's --chart-*
@@ -64,21 +69,30 @@ function detectLang(source: string): DiagramLang {
   return 'flow'
 }
 
-function layoutFor(lang: DiagramLang, source: string, theme: TrazoTheme): PositionedGraph {
+function layoutFor(
+  lang: DiagramLang,
+  source: string,
+  theme: TrazoTheme
+): PositionedGraph {
   switch (lang) {
     case 'sequence': {
       const { graph, error } = parseSequence(source)
-      if (error) throw new Error(`trazo sequence DSL line ${error.line}: ${error.message}`)
+      if (error)
+        throw new Error(
+          `trazo sequence DSL line ${error.line}: ${error.message}`
+        )
       return layoutSequence(graph)
     }
     case 'block': {
       const { graph, error } = parseBlock(source)
-      if (error) throw new Error(`trazo block DSL line ${error.line}: ${error.message}`)
+      if (error)
+        throw new Error(`trazo block DSL line ${error.line}: ${error.message}`)
       return layoutBlock(graph)
     }
     case 'git': {
       const { graph, error } = parseGit(source)
-      if (error) throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
+      if (error)
+        throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
       // Horizontal orientation reads like a real `git log --graph` timeline
       // (commits left→right, branches as rows) instead of trazo's default
       // vertical lane, which crams every commit label into one narrow column.
@@ -90,7 +104,14 @@ function layoutFor(lang: DiagramLang, source: string, theme: TrazoTheme): Positi
     }
     default: {
       const { graph, error } = parseFlow(source)
-      if (error) throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
+      if (error)
+        throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
+      // House rule (see CLAUDE.md "Diagram conventions"): connectors are never
+      // colored — an arrow/lane always renders in the neutral accent color, never
+      // a source node's role color. Neutralize trazo's per-edge `colored` flag
+      // here so a colored token (`===`/`==>`/`<==`/`<==>`) anywhere in the DSL
+      // can't reintroduce a colored lane. Only node fills carry role color.
+      for (const edge of graph.edges) edge.colored = false
       return layoutFlow(graph, themeFlowOptions(theme))
     }
   }
@@ -160,7 +181,12 @@ export function Diagram({
       )}
       {graph ? (
         <div className="relative flex justify-center px-6 py-12 [&_svg]:max-w-full">
-          <Graph graph={graph} title={title} className={className} theme={theme} />
+          <Graph
+            graph={graph}
+            title={title}
+            className={className}
+            theme={theme}
+          />
         </div>
       ) : (
         <div className="relative overflow-x-auto px-6 py-12">

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -30,7 +30,15 @@ import { cn } from '@/lib/utils'
 const graphTheme: TrazoTheme = {
   ...joycoTheme,
   background: 'none',
-  tokens: { ...joycoTheme.tokens, bg: 'var(--card)' },
+  tokens: {
+    ...joycoTheme.tokens,
+    bg: 'var(--card)',
+    // Inline `code` chips read as plain monospace text, not a boxed chip: no
+    // background fill, and the glyph color `inherit`s the parent node label's
+    // own foreground (each node's role foreground) instead of a fixed token.
+    code: 'transparent',
+    'code-foreground': 'inherit',
+  },
 }
 
 // Git branches map onto lane-1, lane-2, … in commit order. This app's --chart-*

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -35,6 +35,7 @@ const graphTheme: TrazoTheme = {
     bg: 'var(--card)',
     'neutral-foreground': 'var(--muted)',
     success: 'var(--color-mint-green)',
+    code: 'oklch(1 0 0 / 0.16)',
   },
 }
 

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -30,15 +30,7 @@ import { cn } from '@/lib/utils'
 const graphTheme: TrazoTheme = {
   ...joycoTheme,
   background: 'none',
-  tokens: {
-    ...joycoTheme.tokens,
-    bg: 'var(--card)',
-    // Inline `code` chips read as plain monospace text, not a boxed chip: no
-    // background fill, and the glyph color `inherit`s the parent node label's
-    // own foreground (each node's role foreground) instead of a fixed token.
-    code: 'transparent',
-    'code-foreground': 'inherit',
-  },
+  tokens: { ...joycoTheme.tokens, bg: 'var(--card)' },
 }
 
 // Git branches map onto lane-1, lane-2, … in commit order. This app's --chart-*

--- a/components/flow.tsx
+++ b/components/flow.tsx
@@ -13,6 +13,10 @@ import {
   joycoTheme,
   type PositionedGraph,
   type TrazoTheme,
+  type FlowGraph,
+  type SequenceGraph,
+  type BlockGraph,
+  type CommitGraph,
 } from '@joycostudio/trazo'
 import { Graph } from '@joycostudio/trazo/react'
 import { Badge } from '@/components/ui/badge'
@@ -36,6 +40,8 @@ const graphTheme: TrazoTheme = {
     'neutral-foreground': 'var(--muted)',
     success: 'var(--color-mint-green)',
     code: 'oklch(1 0 0 / 0.16)',
+    'code-foreground': 'inherit',
+    
   },
 }
 
@@ -70,43 +76,41 @@ function detectLang(source: string): DiagramLang {
   return 'flow'
 }
 
-function layoutFor(
-  lang: DiagramLang,
-  source: string,
-  theme: TrazoTheme
-): PositionedGraph {
-  switch (lang) {
-    case 'sequence': {
-      const { graph, error } = parseSequence(source)
-      if (error)
-        throw new Error(
-          `trazo sequence DSL line ${error.line}: ${error.message}`
-        )
+// A trazo graph a `<Diagram>` can render — either authored as a string DSL and
+// parsed here, or handed in already-parsed from a `flow`/`seq`/`git`/`block`
+// tagged-template call (which validates the DSL at build time).
+export type DiagramGraph = FlowGraph | SequenceGraph | BlockGraph | CommitGraph
+
+// The commit graph is the only trazo graph without a `kind` discriminator — it
+// carries `commits`/`refs` instead — so it's identified by the absence of `kind`.
+function isCommitGraph(graph: DiagramGraph): graph is CommitGraph {
+  return !('kind' in graph)
+}
+
+function themeFor(graph: DiagramGraph): TrazoTheme {
+  return isCommitGraph(graph) ? gitTheme : graphTheme
+}
+
+// Lay out an already-parsed graph. Both entry points (string DSL and the
+// tagged-template graphs) funnel through here so the git/flow rules stay in one
+// place.
+function layoutParsed(graph: DiagramGraph, theme: TrazoTheme): PositionedGraph {
+  if (isCommitGraph(graph)) {
+    // Horizontal orientation reads like a real `git log --graph` timeline
+    // (commits left→right, branches as rows) instead of trazo's default
+    // vertical lane, which crams every commit label into one narrow column.
+    // labelSide 'left' places commit labels ABOVE the lane in a horizontal chart.
+    return layoutGit(
+      graph,
+      themeGitOptions(theme, { orientation: 'horizontal', labelSide: 'left' })
+    )
+  }
+  switch (graph.kind) {
+    case 'sequence':
       return layoutSequence(graph)
-    }
-    case 'block': {
-      const { graph, error } = parseBlock(source)
-      if (error)
-        throw new Error(`trazo block DSL line ${error.line}: ${error.message}`)
+    case 'block':
       return layoutBlock(graph)
-    }
-    case 'git': {
-      const { graph, error } = parseGit(source)
-      if (error)
-        throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
-      // Horizontal orientation reads like a real `git log --graph` timeline
-      // (commits left→right, branches as rows) instead of trazo's default
-      // vertical lane, which crams every commit label into one narrow column.
-      // labelSide 'left' places commit labels ABOVE the lane in a horizontal chart.
-      return layoutGit(
-        graph,
-        themeGitOptions(theme, { orientation: 'horizontal', labelSide: 'left' })
-      )
-    }
     default: {
-      const { graph, error } = parseFlow(source)
-      if (error)
-        throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
       // House rule (see CLAUDE.md "Diagram conventions"): connectors are never
       // colored — an arrow/lane always renders in the neutral accent color, never
       // a source node's role color. Neutralize trazo's per-edge `colored` flag
@@ -114,6 +118,39 @@ function layoutFor(
       // can't reintroduce a colored lane. Only node fills carry role color.
       for (const edge of graph.edges) edge.colored = false
       return layoutFlow(graph, themeFlowOptions(theme))
+    }
+  }
+}
+
+// Parse a string DSL to a graph, dispatching on the detected language. Parse
+// errors are surfaced with the offending line.
+function parseSource(lang: DiagramLang, source: string): DiagramGraph {
+  switch (lang) {
+    case 'sequence': {
+      const { graph, error } = parseSequence(source)
+      if (error)
+        throw new Error(
+          `trazo sequence DSL line ${error.line}: ${error.message}`
+        )
+      return graph
+    }
+    case 'block': {
+      const { graph, error } = parseBlock(source)
+      if (error)
+        throw new Error(`trazo block DSL line ${error.line}: ${error.message}`)
+      return graph
+    }
+    case 'git': {
+      const { graph, error } = parseGit(source)
+      if (error)
+        throw new Error(`trazo git DSL line ${error.line}: ${error.message}`)
+      return graph
+    }
+    default: {
+      const { graph, error } = parseFlow(source)
+      if (error)
+        throw new Error(`trazo flow DSL line ${error.line}: ${error.message}`)
+      return graph
     }
   }
 }
@@ -126,7 +163,10 @@ export function Diagram({
   className,
   ascii = false,
 }: {
-  children: string
+  // A string DSL (parsed here) or a graph from a `flow`/`seq`/`git`/`block`
+  // tagged-template call (parsed at the call site, so the DSL is validated at
+  // build time). `ascii` mode requires a string.
+  children: string | DiagramGraph
   title?: string
   index?: number
   articleNumber?: string
@@ -136,10 +176,25 @@ export function Diagram({
   // one — e.g. git commit graphs whose commits the prose refers to by letter.
   ascii?: boolean
 }) {
-  const source = String(children).trim()
-  const lang = ascii ? undefined : detectLang(source)
-  const theme = lang === 'git' ? gitTheme : graphTheme
-  const graph = lang ? layoutFor(lang, source, theme) : null
+  // ASCII mode always takes a raw string and renders it verbatim.
+  const asciiSource =
+    ascii && typeof children === 'string' ? children.trim() : null
+
+  // Resolve the theme (needed for both layout and the <Graph> paint pass) and
+  // lay out, from whichever form `children` arrived in.
+  let theme = graphTheme
+  let graph: PositionedGraph | null = null
+  if (!ascii) {
+    if (typeof children === 'string') {
+      const source = children.trim()
+      const parsed = parseSource(detectLang(source), source)
+      theme = themeFor(parsed)
+      graph = layoutParsed(parsed, theme)
+    } else {
+      theme = themeFor(children)
+      graph = layoutParsed(children, theme)
+    }
+  }
 
   // The corner tag reads `N{article}-{illustration}` (e.g. N07-01): the log's
   // number, injected per-page, paired with this diagram's order in the article.
@@ -197,7 +252,7 @@ export function Diagram({
               className
             )}
           >
-            {source}
+            {asciiSource}
           </pre>
         </div>
       )}

--- a/content/logs/07-nextjs-promises-ppr.mdx
+++ b/content/logs/07-nextjs-promises-ppr.mdx
@@ -378,8 +378,8 @@ Compare this to the traditional approach where nothing renders for 350ms.
 ### Without promise forwarding (traditional)
 
 <Diagram index={5} title="Traditional: slow TTFB, fast render">{`sequenceDiagram
-participant S[Server]
-participant C[Client]
+participant S[Server]:primary
+participant C[Client]:success
 note over C: Blank screen…
 S->>S: await getCart() (200ms)
 S->>S: await getFlags() (150ms)
@@ -392,8 +392,8 @@ note over S,C: Slow TTFB, fast render`}</Diagram>
 ### With promise forwarding + PPR
 
 <Diagram index={6} title="Promise forwarding + PPR: fast TTFB, progressive render">{`sequenceDiagram
-participant S[Server]
-participant C[Client]
+participant S[Server]:primary
+participant C[Client]:success
 S->>S: Start getCart()
 S->>S: Start getFlags()
 S->>C: Static shell + fallbacks (instant)

--- a/content/logs/07-nextjs-promises-ppr.mdx
+++ b/content/logs/07-nextjs-promises-ppr.mdx
@@ -410,14 +410,14 @@ note over S,C: Fast TTFB, progressive render`}</Diagram>
 Here's the complete picture of how a request flows through the system with promise forwarding and PPR:
 
 <Diagram index={7} title="Full request flow with promise forwarding + PPR">{`flow TD
-subgraph build ["BUILD TIME"]
+subgraph build ["BUILD TIME"]:info
 B1["Next.js prerenders the route"]
 B2["Static Shell<br/>html, body, nav, main, footer<br/>Suspense fallbacks<br/>All non-dynamic content"]
 B3[("CDN / Edge Cache")]:primary
 B1 --- B2
 B2 --- B3
 end
-subgraph request ["REQUEST TIME"]
+subgraph request ["REQUEST TIME"]:success
 R1["CDN serves static shell"]
 R2["Browser paints immediately"]:success
 R3["Server executes layout"]

--- a/content/logs/07-nextjs-promises-ppr.mdx
+++ b/content/logs/07-nextjs-promises-ppr.mdx
@@ -32,8 +32,8 @@ export default async function RootLayout({ children }) {
 
 <Diagram index={1} title="Blocking await chain">{`flow TD
 A(["Request arrives"]):primary
-B["await getCart()<br/>200ms"]:error
-C["await getFlags()<br/>150ms"]:error
+B["await \`getCart()\`<br/>200ms"]:error
+C["await \`getFlags()\`<br/>150ms"]:error
 D["Render HTML"]
 E["Send response<br/>350ms+ later"]:error
 A --- B
@@ -71,9 +71,9 @@ The layout returns immediately. The promises are in-flight. Client components re
 
 <Diagram index={2} title="Forward promises, render shell immediately">{`flow TD
 A(["Request arrives"]):primary
-B["getCart() started"]:success
-C["getFlags() started"]:success
-D["Render HTML shell immediately<br/>(Suspense fallbacks)"]:primary
+B["\`getCart()\` started"]:success
+C["\`getFlags()\` started"]:success
+D["Render HTML shell immediately<br/>(\`<Suspense>\` fallbacks)"]:primary
 E["Stream resolved data<br/>as promises settle"]:info
 A --- B
 A --- C
@@ -341,11 +341,11 @@ With **Partial Prerendering** (PPR), enabled via `cacheComponents: true` in Next
 
 <Diagram index={3} title="The static shell: built at build time, served from CDN">{`flow TD
 shell(["Static Shell: built at build time, served from CDN"])
-nav["<nav> Store </nav>"]:primary
-skeleton1["CartTotal skeleton"]:warning
-skeleton2["CartCount skeleton"]:warning
-main["<main> Featured Products"]:primary
-fallback["Checkout button fallback"]:warning
+nav["\`<nav>\` Store \`</nav>\`"]:primary
+skeleton1["\`CartTotal\` skeleton"]:warning
+skeleton2["\`CartCount\` skeleton"]:warning
+main["\`<main>\` Featured Products"]:primary
+fallback["\`CheckoutButton\` fallback"]:warning
 shell --- nav
 nav --- skeleton1
 nav --- skeleton2
@@ -357,11 +357,11 @@ When a request comes in, the static shell is **instantly** served. Then the dyna
 
 <Diagram index={4} title="Shell served instantly, dynamic parts stream in">{`flow TD
 A(["Static shell served<br/>0ms"]):primary
-S["UI renders with<br/>Suspense fallbacks instantly"]:warning
-B["getFlags resolves<br/>80ms"]:success
-C["getCart resolves<br/>120ms"]:success
-D["CheckoutButton renders<br/>Checkout with Express Pay"]:info
-E["CartCount: 3<br/>CartTotal: $149.97"]:info
+S["UI renders with<br/>\`<Suspense>\` fallbacks instantly"]:warning
+B["\`getFlags()\` resolves<br/>80ms"]:success
+C["\`getCart()\` resolves<br/>120ms"]:success
+D["\`CheckoutButton\` renders<br/>Checkout with Express Pay"]:info
+E["\`CartCount\`: 3<br/>\`CartTotal\`: $149.97"]:info
 F(["Page fully interactive<br/>~120ms"]):success
 A --- S
 S --- B

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -265,12 +265,10 @@ The compositor scroll creates a delta between where the canvas sits (page space)
 Edge clipping during fast scroll is solved by rendering the canvas larger than the viewport. Add 25% vertical padding top and bottom (canvas = 150% viewport height). Adding this padding buffer lets the translate catch up when the impl layer syncs. Even with a few frames of stale transform, the extra rendered area covers the viewport:
 
 <Diagram index={8} title="Padding absorbs the stale-transform shift">{`flow TD
-subgraph canvas ["Canvas (150% viewport height)"]
+subgraph canvas ["Canvas (150% viewport height)"]:info
 PAD_TOP["25% padding (top)<br/>Extra rendered area"]:success
 VP["100% viewport area<br/>What the user actually sees"]:primary
 PAD_BOT["25% padding (bottom)<br/>Extra rendered area"]:success
-PAD_TOP --- VP
-VP --- PAD_BOT
 end
 SCROLL["During fast scroll,<br/>stale transform shifts canvas<br/>a few pixels"]
 NOTE["Padding absorbs the shift<br/>→ no visible clipping"]:success

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -39,7 +39,7 @@ The compositor updates what the user sees **immediately**. The main thread gets 
 When JS modifies a transform via `requestAnimationFrame`, the change has to travel through Chromium's full pipeline before it reaches the screen:
 
 <Diagram index={2} title="The full Chromium render pipeline">{`flow TD
-subgraph main ["Main Thread"]
+subgraph main ["Main Thread"]:info
 S["Style"]:primary
 L["Layout"]:primary
 PP["Pre-paint"]:primary
@@ -48,10 +48,10 @@ S --- L
 L --- PP
 PP --- P
 end
-subgraph commit ["Commit"]
+subgraph commit ["Commit"]:primary
 CO["Copy layer tree +<br/>property trees to impl thread<br/>(main thread blocked)"]:warning
 end
-subgraph impl ["Compositor Thread (impl)"]
+subgraph impl ["Compositor Thread (impl)"]:warning
 LY["Layerize"]:success
 R["Raster<br/>(worker threads → GPU tiles)"]:success
 AC["Activate"]:success

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -166,10 +166,10 @@ function animate(time: number) {
 JS drives `scrollTop` each frame, so the compositor and JS are always in agreement. There's no race. The DOM scrolls to exactly where JS told it to, and the canvas renders with the same value.
 
 <Diagram index={5} title="JS-driven scroll frame sequence">{`sequenceDiagram
-participant U[User Input]
-participant M[Main Thread (Lenis)]
-participant C[Compositor]
-participant S[Screen]
+participant U[User Input]:warning
+participant M[Main Thread (Lenis)]:primary
+participant C[Compositor]:success
+participant S[Screen]:info
 note over U: User scrolls
 U->>M: Scroll input
 note over M: rAF callback
@@ -239,9 +239,9 @@ function animate() {
 The canvas and DOM move together on the compositor, with no content drift. The only stale thing is the `transform` correction that repositions the canvas over the viewport. Here's what a single scroll looks like:
 
 <Diagram index={7} title="Absolute approach: edge drift sequence">{`sequenceDiagram
-participant C[Compositor]
-participant P[Page (canvas + DOM)]
-participant M[Main Thread]
+participant C[Compositor]:success
+participant P[Page (canvas + DOM)]:info
+participant M[Main Thread]:primary
 note over P: Initial state:<br/>scrollY = 500<br/>transform: translateY(500px)<br/>Canvas perfectly covers viewport
 note over C: User scrolls 40px
 C->>P: Compositor moves page to scrollY=540<br/>(canvas + DOM shift together, instant)
@@ -284,9 +284,9 @@ This is the main tradeoff of the absolute approach. The canvas lives on the **P*
 To keep a WebGL element fixed on screen, you don't need to translate anything. It would just sit at its viewport position. The problem is that the canvas is on the page side. When the compositor scrolls, it takes the entire canvas with it, including your "fixed" element. That compositor scroll instantly displaces it. JS hasn't caught up yet, so for that frame the element slides with the page when it should have stayed put. That's the jelly. The element gets dragged by the compositor scroll until the next rAF where JS can correct it back.
 
 <Diagram index={9} title="The fixed-element jelly sequence">{`sequenceDiagram
-participant C[Compositor]
-participant P[Page (canvas here)]
-participant M[Main Thread]
+participant C[Compositor]:success
+participant P[Page (canvas here)]:info
+participant M[Main Thread]:primary
 note over P: "Fixed" element sitting at<br/>its viewport position on the canvas
 note over C: User scrolls 40px
 C->>P: Compositor moves page to scrollY=540<br/>(entire canvas shifts, including the "fixed" element)

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -76,7 +76,7 @@ end
 subgraph impl ["Impl Thread"]
 LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]:success
 end
-LTH <==>|"commit (sync) / scroll deltas (async)"| LTHI`}</Diagram>
+LTH <==>|commit (sync) / scroll deltas (async)| LTHI`}</Diagram>
 
 The impl tree is a snapshot from the last commit. Between commits, the impl thread scrolls, animates, and draws frames without consulting the main thread. When your rAF fires and reads `window.scrollY`, it's reading the scroll offset from the *last time the impl thread synced*, not the impl thread's current position.
 
@@ -137,7 +137,7 @@ end
 subgraph page ["Page (P)"]
 CONTENT["DOM content"]:success
 end
-VIEW ===|"D (delta): JS animates scrollTop, reads it back for canvas"| CONTENT`}</Diagram>
+VIEW ===|D (delta): JS animates scrollTop, reads it back for canvas| CONTENT`}</Diagram>
 
 JS is the **single source of truth**. On each frame, Lenis lerps toward the target scroll position, sets `scrollTop`, and your rAF callback reads it back for the canvas. Because both the DOM scroll and the WebGL render happen from the same value in the same frame, there's **zero drift** between them.
 
@@ -204,7 +204,7 @@ subgraph page ["Page (P)"]
 CANVAS["Canvas<br/>(absolute, in page flow)"]:info
 DOM["DOM elements"]:success
 end
-VIEW ===|"D (delta): JS reads scrollY, applies transform to reposition canvas"| CANVAS`}</Diagram>
+VIEW ===|D (delta): JS reads scrollY, applies transform to reposition canvas| CANVAS`}</Diagram>
 
 The canvas sits on the **P** side. The compositor moves the page, and the canvas with it, instantly. DOM elements and the canvas move together on the GPU. JS only needs to correct the canvas position and re-render the WebGL scene.
 

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -138,7 +138,7 @@ end
 subgraph page ["Page (P)"]
 CONTENT["DOM content"]:success
 end
-VIEW ===|D (delta): JS animates scrollTop, reads it back for canvas| CONTENT`}</Diagram>
+VIEW ===|D (delta): JS animates scrollTop,<br/>reads it back for canvas| CONTENT`}</Diagram>
 
 JS is the **single source of truth**. On each frame, Lenis lerps toward the target scroll position, sets `scrollTop`, and your rAF callback reads it back for the canvas. Because both the DOM scroll and the WebGL render happen from the same value in the same frame, there's **zero drift** between them.
 
@@ -205,7 +205,7 @@ subgraph page ["Page (P)"]
 CANVAS["Canvas<br/>(absolute, in page flow)"]:info
 DOM["DOM elements"]:success
 end
-VIEW ===|D (delta): JS reads scrollY, applies transform to reposition canvas| CANVAS`}</Diagram>
+VIEW ===|D (delta): JS reads scrollY,<br/>applies transform to reposition canvas| CANVAS`}</Diagram>
 
 The canvas sits on the **P** side. The compositor moves the page, and the canvas with it, instantly. DOM elements and the canvas move together on the GPU. JS only needs to correct the canvas position and re-render the WebGL scene.
 

--- a/content/logs/08-webgl-scroll-sync.mdx
+++ b/content/logs/08-webgl-scroll-sync.mdx
@@ -76,7 +76,8 @@ end
 subgraph impl ["Impl Thread"]
 LTHI["LayerTreeHostImpl<br/>owns impl-thread tree"]:success
 end
-LTH <==>|commit (sync) / scroll deltas (async)| LTHI`}</Diagram>
+LTH -->|commit (periodic sync)| LTHI
+LTHI -->|scroll deltas (async notify)| LTH`}</Diagram>
 
 The impl tree is a snapshot from the last commit. Between commits, the impl thread scrolls, animates, and draws frames without consulting the main thread. When your rAF fires and reads `window.scrollY`, it's reading the scroll offset from the *last time the impl thread synced*, not the impl thread's current position.
 

--- a/content/logs/11-wtf-is-layout-thrashing.mdx
+++ b/content/logs/11-wtf-is-layout-thrashing.mdx
@@ -21,8 +21,7 @@ js --- style
 style --- layout
 layout --- paint
 paint --- composite
-cry["this one makes fps cry 😢"]:neutral
-cry --> layout
+note layout below "this one makes fps cry 😢"
 `}</Diagram>
 
 1. **JavaScript**: your code runs: event handlers, `requestAnimationFrame` callbacks, GSAP tweens, React commits. Any DOM mutations happen here.

--- a/content/logs/12-the-render-pipeline.mdx
+++ b/content/logs/12-the-render-pipeline.mdx
@@ -21,7 +21,7 @@ js --- style
 style --- layout
 layout --- paint
 end
-subgraph compositor ["Compositor Thread"]
+subgraph compositor ["Compositor Thread"]:error
 composite["Composite"]:error
 end
 paint === composite

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -14,13 +14,8 @@ The long answer is a story. Let me introduce you to Elvira and Homero.
 
 Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
 
-<Diagram index={1} title="Stacked branches">{`
-flow LR
-main["main"]:primary
-elvira["elvira/checkout"]:success
-homero["homero/receipts"]:info
-main ===|"base of"| elvira
-elvira ===|"base of"| homero
+<Diagram index={1} ascii title="Stacked branches">{`
+main ◀── based on ── elvira/checkout ◀── based on ── homero/receipts
 `}</Diagram>
 
 A stacked branch. Totally normal, this is how parallel work on dependent features should happen.

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -19,8 +19,8 @@ flow LR
 main["main"]:primary
 elvira["elvira/checkout"]:success
 homero["homero/receipts"]:info
-main ===|base of| elvira
-elvira ===|base of| homero
+main <==|base of| elvira
+elvira <==|base of| homero
 `}</Diagram>
 
 A stacked branch. Totally normal, this is how parallel work on dependent features should happen.

--- a/content/logs/14-phantom-merge-conflicts.mdx
+++ b/content/logs/14-phantom-merge-conflicts.mdx
@@ -14,8 +14,13 @@ The long answer is a story. Let me introduce you to Elvira and Homero.
 
 Elvira has been working on the new checkout flow in `elvira/checkout`. Homero needs the checkout API for his receipt page, and he's not going to sit around waiting for Elvira's PR to land. So he branches off her branch:
 
-<Diagram index={1} ascii title="Stacked branches">{`
-main ◀── based on ── elvira/checkout ◀── based on ── homero/receipts
+<Diagram index={1} title="Stacked branches">{`
+flow LR
+main["main"]:primary
+elvira["elvira/checkout"]:success
+homero["homero/receipts"]:info
+main ===|base of| elvira
+elvira ===|base of| homero
 `}</Diagram>
 
 A stacked branch. Totally normal, this is how parallel work on dependent features should happen.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.5.0",
+    "@joycostudio/trazo": "^0.6.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.9.0",
+    "@joycostudio/trazo": "^0.10.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.6.0",
+    "@joycostudio/trazo": "^0.7.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.7.0",
+    "@joycostudio/trazo": "^0.7.1",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@diceui/mention": "^0.8.0",
     "@gsap/react": "^2.1.2",
     "@joycostudio/marquee": "^0.0.12",
-    "@joycostudio/trazo": "^0.7.1",
+    "@joycostudio/trazo": "^0.9.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.7.1
-        version: 0.7.1(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.9.0
+        version: 0.9.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -919,8 +919,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.7.1':
-    resolution: {integrity: sha512-AlQS/POV56GsJrJgmMZ7SXrhLNoXGeFdzLqLcEhkWWiJGKHmj7CgOb2BqpVygptGWlzUc/L/4PvxnKHPhQfCaQ==}
+  '@joycostudio/trazo@0.9.0':
+    resolution: {integrity: sha512-+lWgAVfKkTOh42dS44Ucv++ygSsW7InGJcxP+SOBY+LGS4kpZRH5uxgPx/vbD2GFeb4lfb+eulsH5vy0DW2DPQ==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6356,7 +6356,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.7.1(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.9.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.7.0
-        version: 0.7.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.7.1
+        version: 0.7.1(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -919,8 +919,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.7.0':
-    resolution: {integrity: sha512-8vxG2TPIvi19aFEYl26fqC+F+k0vXwqvo14WJmt8rVkSUgjW9WAY3FUt8O5E3rSX2oagSccnqHlMAiVbkaGmpw==}
+  '@joycostudio/trazo@0.7.1':
+    resolution: {integrity: sha512-AlQS/POV56GsJrJgmMZ7SXrhLNoXGeFdzLqLcEhkWWiJGKHmj7CgOb2BqpVygptGWlzUc/L/4PvxnKHPhQfCaQ==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6356,7 +6356,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.7.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.7.1(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.6.0
-        version: 0.6.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.7.0
+        version: 0.7.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -919,8 +919,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.6.0':
-    resolution: {integrity: sha512-r4t02LD8vuf017H93Me1+RXOS8X2rT6iTDlNA1yfBGgdIIpRReKFoPvHEWua/VTv/jd68aSY42xcsKNpOF4+sw==}
+  '@joycostudio/trazo@0.7.0':
+    resolution: {integrity: sha512-8vxG2TPIvi19aFEYl26fqC+F+k0vXwqvo14WJmt8rVkSUgjW9WAY3FUt8O5E3rSX2oagSccnqHlMAiVbkaGmpw==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6356,7 +6356,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.6.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.7.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.9.0
-        version: 0.9.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.10.0
+        version: 0.10.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -919,8 +919,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.9.0':
-    resolution: {integrity: sha512-+lWgAVfKkTOh42dS44Ucv++ygSsW7InGJcxP+SOBY+LGS4kpZRH5uxgPx/vbD2GFeb4lfb+eulsH5vy0DW2DPQ==}
+  '@joycostudio/trazo@0.10.0':
+    resolution: {integrity: sha512-oEq614BnXAkOg/q6Kn/N0KQ8CSMXaF+B81RkQQjGHUnfJPwThKdxt+fvfU4ZCl/LOgALGqTN/d/y+85t6EJ3tA==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6356,7 +6356,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.9.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.10.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12(react@19.2.0)
       '@joycostudio/trazo':
-        specifier: ^0.5.0
-        version: 0.5.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^0.6.0
+        version: 0.6.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.5))(@types/react@19.2.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -919,8 +919,8 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
-  '@joycostudio/trazo@0.5.0':
-    resolution: {integrity: sha512-VZgHBF8+PaGeE+eNpubIYuIbNdgqYNc2JKQS9PWvan64g8pdqizB2CkBAmRoMSTFzo8hqJlubpKgFe1kkBCehg==}
+  '@joycostudio/trazo@0.6.0':
+    resolution: {integrity: sha512-r4t02LD8vuf017H93Me1+RXOS8X2rT6iTDlNA1yfBGgdIIpRReKFoPvHEWua/VTv/jd68aSY42xcsKNpOF4+sw==}
     peerDependencies:
       eslint: '>=9'
       react: '>=18'
@@ -6356,7 +6356,7 @@ snapshots:
     dependencies:
       react: 19.2.0
 
-  '@joycostudio/trazo@0.5.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@joycostudio/trazo@0.6.0(eslint@9.39.1(jiti@2.6.1))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       react: 19.2.0


### PR DESCRIPTION
## Problem

The trazo diagram migration needs a fast way to show a reviewer the before/after — every diagram now rendered with `@joycostudio/trazo` next to whatever it replaced on `main` (a Mermaid chart, an Excalidraw screenshot, or a plain-text snippet).

## Result

Adds an unlinked, `noindex` review page at `/diagram-comparison` that renders all 22 diagrams across 5 logs (07, 08, 11, 12, 14) side-by-side, with a theme switcher since both renderers are theme-aware. This is a throwaway artifact meant to be viewed via the PR preview deploy and deleted afterward — it does not touch the em-dash/trazo diagram work, which is already present on the target branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a temporary page for reviewing the Trazo diagram migration. The main changes are:

- A noindex `/diagram-comparison` route with 22 before-and-after diagrams.
- Mermaid, screenshot, plain-text, and Trazo comparison panels.
- A theme switcher for light, dark, radio, and terminal themes.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small image-loading cleanup.

- The route uses the existing Diagram, Mermaid, and theme-provider contracts.
- The comparison entries have unique keys and valid client/server boundaries.
- The only identified issue is eager loading of two far-below-fold screenshots.

app/diagram-comparison/page.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/diagram-comparison/page.tsx | Adds the comparison route, static diagram data, and renderers for the before-and-after panels; the below-fold screenshots should use lazy loading. |
| app/diagram-comparison/theme-switcher.tsx | Adds a client-side switcher using the four themes already configured by the application. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
app/diagram-comparison/page.tsx:783-789
**Below-Fold Images Load Eagerly**

These screenshots appear after 17 diagram comparisons, but native images load eagerly by default. Opening the page downloads both large R2 assets immediately, competing with the Mermaid and Trazo content above them. Guideline: Image Optimization. Reference: https://registry.joyco.studio/toolbox/pr-guidelines#image-optimization

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(logs): add temp trazo diagram befo..."](https://github.com/joyco-studio/hub/commit/cd4fc3d4004bc247c1967c651fa67e89ca991a4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44452845)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - Registry Guidelines ([source](https://app.greptile.com/joyco/-/custom-context?memory=465d8e46-ae60-4ffc-9fcb-2e307242982d))
- Context used - AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=a962b349-a672-423b-bf7c-e75108c1663a))
- Context used - public/AGENTS.md ([source](https://app.greptile.com/joyco/github/joyco-studio/hub/-/custom-context?memory=bd6e51dd-d00f-4964-8514-35f52767b2de))
</details>

<!-- /greptile_comment -->