### PR TITLE
Add LLM-friendly toolbox libraries index

### DIFF
--- a/components/category-index.tsx
+++ b/components/category-index.tsx
@@ -29,15 +29,14 @@ export async function CategoryIndex({
 }) {
   const pages = getCategoryPages(category, pageType)
 
-  // Toolbox: pull featured tools out to highlight as cards. Both groups keep the
-  // page-tree order (creation date, newest first).
+  // The main toolbox index pulls featured tools out of the list. Filtered
+  // indexes keep the cards while repeating every result in the complete list.
   const isToolbox = category === 'toolbox'
   const featuredPages = isToolbox
     ? pages.filter((page) => page.data.featured)
     : []
-  const listPages = isToolbox
-    ? pages.filter((page) => !page.data.featured)
-    : pages
+  const listPages =
+    isToolbox && !pageType ? pages.filter((page) => !page.data.featured) : pages
 
   const typeMap: Record<keyof RegistryCounts, ItemType> = {
     components: 'component',

--- a/components/category-index.tsx
+++ b/components/category-index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { source } from '@/lib/source'
+import { getCategoryPages, type DocumentPageType } from '@/lib/source'
 import { CategoryIndexBadge } from './category-index-badge'
 import { PreviewCard } from '@/components/cards'
 import { GltfIcon, MetriIcon, SunoIcon } from '@/components/icons'
@@ -20,45 +20,14 @@ import { EyeIcon } from 'lucide-react'
 import { Fragment } from 'react'
 import { cn } from '@/lib/utils'
 
-type PageTreeNode = {
-  type?: string
-  $id?: string
-  url?: string
-  children?: PageTreeNode[]
-}
-
-function getPageTreeOrder(category: string): string[] {
-  const children = source.pageTree.children as unknown as PageTreeNode[]
-  const folder = children.find(
-    (child) => child.type === 'folder' && child.$id?.split(':')[1] === category
-  )
-  if (!folder?.children) return []
-  return folder.children
-    .filter((child) => child.type === 'page' && child.url)
-    .map((child) => child.url!)
-}
-
 export async function CategoryIndex({
   category,
+  pageType,
 }: {
   category: keyof RegistryCounts
+  pageType?: DocumentPageType
 }) {
-  const pages = source
-    .getPages()
-    .filter((page) => page.slugs[0] === category && page.slugs.length > 1)
-
-  // Sort pages based on meta.json order (reflected in the page tree)
-  const pageTreeOrder = getPageTreeOrder(category)
-  if (pageTreeOrder.length > 0) {
-    const orderMap = new Map(pageTreeOrder.map((url, i) => [url, i]))
-    pages.sort((a, b) => {
-      const aIndex = orderMap.get(a.url) ?? Infinity
-      const bIndex = orderMap.get(b.url) ?? Infinity
-      return aIndex - bIndex
-    })
-  }
-
-  if (category === 'logs') pages.reverse()
+  const pages = getCategoryPages(category, pageType)
 
   // Toolbox: pull featured tools out to highlight as cards. Both groups keep the
   // page-tree order (creation date, newest first).

--- a/content/toolbox/libraries.mdx
+++ b/content/toolbox/libraries.mdx
@@ -1,0 +1,10 @@
+---
+title: Libraries
+description: Libraries created and documented by JOYCO Studio.
+---
+
+import { CategoryIndex } from '@/components/category-index'
+
+This is the canonical index of JOYCO libraries documented in the toolbox. Use the Markdown version at [`/toolbox/libraries.md`](/toolbox/libraries.md) as input for LLMs and other text-based tools.
+
+<CategoryIndex category="toolbox" pageType="library" />

--- a/content/toolbox/libraries.mdx
+++ b/content/toolbox/libraries.mdx
@@ -5,6 +5,4 @@ description: Libraries created and documented by JOYCO Studio.
 
 import { CategoryIndex } from '@/components/category-index'
 
-This is the canonical index of JOYCO libraries documented in the toolbox. Use the Markdown version at [`/toolbox/libraries.md`](/toolbox/libraries.md) as input for LLMs and other text-based tools.
-
 <CategoryIndex category="toolbox" pageType="library" />

--- a/content/toolbox/libraries.mdx
+++ b/content/toolbox/libraries.mdx
@@ -1,5 +1,5 @@
 ---
-title: Libraries
+title: Studio Libraries
 description: Libraries created and documented by JOYCO Studio.
 ---
 

--- a/content/toolbox/metri.mdx
+++ b/content/toolbox/metri.mdx
@@ -1,6 +1,6 @@
 ---
 title: Metri
-description: Metri library by JOYCO Studio.
+description: A DOM measurement engine with cached bounds, pooled observers, scroll tracking, and React bindings.
 type: library
 featured: true
 repo: joyco-studio/metri

--- a/content/toolbox/suno.mdx
+++ b/content/toolbox/suno.mdx
@@ -1,6 +1,6 @@
 ---
 title: Suno
-description: Web Audio library by JOYCO Studio.
+description: A typed Web Audio engine for loading, playback, effects routing, fades, and React bindings.
 type: library
 featured: true
 repo: joyco-studio/suno

--- a/content/toolbox/susano.mdx
+++ b/content/toolbox/susano.mdx
@@ -1,6 +1,6 @@
 ---
 title: Susano
-description: Susano library by JOYCO Studio.
+description: A typed asset loader with deduplicated caching, batch progress, postprocessing, and pluggable loader types.
 type: library
 repo: joyco-studio/susano
 ---

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -58,10 +58,20 @@ export function getPageImage(page: InferPageType<typeof source>) {
  * Resolve a category's pages in the same order the `CategoryIndex` component
  * renders them, so the LLM/raw markdown matches what a browser sees.
  */
-function getCategoryPages(category: string) {
+export type DocumentPageType = InferPageType<typeof source>['data']['type']
+
+export function getCategoryPages(
+  category: string,
+  pageType?: DocumentPageType
+) {
   const pages = source
     .getPages()
-    .filter((page) => page.slugs[0] === category && page.slugs.length > 1)
+    .filter(
+      (page) =>
+        page.slugs[0] === category &&
+        page.slugs.length > 1 &&
+        (!pageType || page.data.type === pageType)
+    )
 
   // Match the page-tree (meta.json / creation-date) order used in the sidebar.
   const folder = getTopLevelFolder(category)
@@ -90,8 +100,11 @@ function getCategoryPages(category: string) {
 const escapeMarkdownLinkText = (text: string) =>
   text.replace(/[[\]()]/g, '\\$&')
 
-function renderCategoryIndexAsMarkdown(category: string): string {
-  const pages = getCategoryPages(category)
+function renderCategoryIndexAsMarkdown(
+  category: string,
+  pageType?: DocumentPageType
+): string {
+  const pages = getCategoryPages(category, pageType)
 
   return pages
     .map((page) => {
@@ -109,7 +122,11 @@ function renderCategoryIndexAsMarkdown(category: string): string {
 }
 
 const categoryIndexRegex =
-  /<CategoryIndex[\s\S]*?category="([^"]+)"[\s\S]*?(?:\/>|<\/CategoryIndex>)/g
+  /<CategoryIndex\b([^>]*?)(?:\/>|>[\s\S]*?<\/CategoryIndex>)/g
+
+function getStringProp(attributes: string, name: string) {
+  return attributes.match(new RegExp(`\\b${name}="([^"]+)"`))?.[1]
+}
 
 export async function getLLMText(page: InferPageType<typeof source>) {
   const llmCompanion = path.join(
@@ -128,9 +145,15 @@ export async function getLLMText(page: InferPageType<typeof source>) {
 
   // Expand `<CategoryIndex category="..." />` into a real markdown list so the
   // raw/.md representation lists every entry instead of an opaque JSX tag.
-  processed = processed.replace(categoryIndexRegex, (_match, category) =>
-    renderCategoryIndexAsMarkdown(category)
-  )
+  processed = processed.replace(categoryIndexRegex, (match, attributes) => {
+    const category = getStringProp(attributes, 'category')
+    if (!category) return match
+
+    const pageType = getStringProp(attributes, 'pageType') as
+      | DocumentPageType
+      | undefined
+    return renderCategoryIndexAsMarkdown(category, pageType)
+  })
 
   let libraryBody = ''
   if (page.data.type === 'library' && page.data.repo) {


### PR DESCRIPTION
## Summary

Adds a canonical `/toolbox/libraries` page that filters toolbox documentation by the existing `library` content type. Extends the shared category query and `CategoryIndex` with an optional page-type filter so browser and Markdown output stay synchronized. `/toolbox/libraries.md` and `llms-full.txt` now expose Metri, Suno, and Susano as ordinary Markdown links.

## Verification

Production build, targeted ESLint, Prettier, and runtime endpoint checks pass; full-repository lint remains blocked by pre-existing unrelated React Compiler violations.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a canonical toolbox libraries page and a shared optional page-type filter that keeps browser and machine-readable category indexes synchronized.

- Moves category page selection and ordering into the shared source module.
- Expands filtered `CategoryIndex` components into ordinary Markdown links.
- Publishes Metri, Suno, and Susano through `/toolbox/libraries`, its Markdown representation, and the full LLM feed.
</details>


<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no concrete blocking or non-blocking issues identified.

The filtered browser and Markdown paths share the same category query, current MDX usages match the parser's supported syntax, and the configured library metadata produces the intended three-entry index.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| components/category-index.tsx | Delegates category selection and ordering to the shared typed helper while preserving existing presentation behavior. |
| content/toolbox/libraries.mdx | Adds the canonical libraries page with a filtered toolbox index and a link to its Markdown representation. |
| lib/source.ts | Adds optional content-type filtering and parses CategoryIndex props so browser and generated Markdown outputs use the same page set and order. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add toolbox libraries index"](https://github.com/joyco-studio/hub/commit/d595b451a265c7eaeaccc73a15818d523609b287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58116970)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Component catalog publishing](https://app.greptile.com/joyco/-/custom-context/knowledge-base/joyco-studio/hub/-/docs/component-catalog.md)
- Knowledge Base — [Content platform services](https://app.greptile.com/joyco/-/custom-context/knowledge-base/joyco-studio/hub/-/docs/content-platform-services.md)
- Knowledge Base — [Content source and MDX processing](https://app.greptile.com/joyco/-/custom-context/knowledge-base/joyco-studio/hub/-/docs/content-source-and-mdx.md)
</details>


<!-- /greptile_comment -->