### PR TITLE
Add Xyz to studio libraries

### DIFF
--- a/content/toolbox/xyz.mdx
+++ b/content/toolbox/xyz.mdx
@@ -1,0 +1,6 @@
+---
+title: Xyz
+description: State ownership primitives, a declarative Tweakpane debug layer, and Three.js scene warmup to kill first-frame hitches.
+type: library
+repo: joyco-studio/xyz
+---


### PR DESCRIPTION
## Summary
- Adds `content/toolbox/xyz.mdx` for `@joycostudio/xyz`, following the same `type: library` frontmatter pattern as `susano.mdx` / `metri.mdx`
- Page content (README) is fetched live from `joyco-studio/xyz` at request time — no static body needed

## Test plan
- [ ] Confirm the page renders at `/toolbox/xyz` and shows up in the Studio Libraries index

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a new Studio Libraries entry for `@joycostudio/xyz`.
- Defines the title, description, library type, and GitHub repository metadata.
- Uses the existing external README loading flow for page content.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The new MDX frontmatter matches the configured content schema and existing library entries, is included by the library index, and uses the existing null-safe README loading path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| content/toolbox/xyz.mdx | Adds a schema-compatible toolbox library entry that follows existing repository and indexing conventions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Xyz to studio libraries"](https://github.com/joyco-studio/hub/commit/6bcf8b866f1395aace28f1cbe811ecf7d761c4a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59834025)</sub>

<!-- /greptile_comment -->